### PR TITLE
Add `definition` and `source` for `vertebrate pest type`

### DIFF
--- a/vocab_files/observable_property_concepts/vertebrate-pest-type.ttl
+++ b/vocab_files/observable_property_concepts/vertebrate-pest-type.ttl
@@ -2,11 +2,14 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 
 <https://linked.data.gov.au/def/test/dawe-cv/85d5f75c-776f-44a3-abe6-e71c695f1754>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:prefLabel "vertebrate pest type" ;
+    skos:definition "The type of vertebrate pest species recorded in a sampling survey area.  Examples include: cat, fox, deer, rabbit, pig, wild dog, camel, etc. " ;
+    dcterms:source "Ecological Field Monitoring protocols - Condition Module, draft v0.1, 30/11/2021" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/master/vocab_files/observable_property_concepts/vertebrate-pest-type.ttl" ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/test/dawe-cv/579449ad-4cea-4272-afa3-67f207941fb1> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/13dec53e-1062-4060-9281-f133c8269afb> ;

--- a/vocab_files/observable_property_concepts/vertebrate-pest-type.ttl
+++ b/vocab_files/observable_property_concepts/vertebrate-pest-type.ttl
@@ -1,15 +1,15 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
-PREFIX dcterms: <http://purl.org/dc/terms/>
 
 <https://linked.data.gov.au/def/test/dawe-cv/85d5f75c-776f-44a3-abe6-e71c695f1754>
     a skos:Concept ;
-    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "vertebrate pest type" ;
-    skos:definition "The type of vertebrate pest species recorded in a sampling survey area.  Examples include: cat, fox, deer, rabbit, pig, wild dog, camel, etc. " ;
     dcterms:source "Ecological Field Monitoring protocols - Condition Module, draft v0.1, 30/11/2021" ;
+    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
+    skos:definition "The type of vertebrate pest species recorded in a sampling survey area.  Examples include: cat, fox, deer, rabbit, pig, wild dog, camel, etc. " ;
+    skos:prefLabel "vertebrate pest type" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/master/vocab_files/observable_property_concepts/vertebrate-pest-type.ttl" ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/test/dawe-cv/579449ad-4cea-4272-afa3-67f207941fb1> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/13dec53e-1062-4060-9281-f133c8269afb> ;


### PR DESCRIPTION
Fixes: #28 