### PR TITLE
Set python version in luts check workflow

### DIFF
--- a/.github/workflows/luts.yml
+++ b/.github/workflows/luts.yml
@@ -10,6 +10,10 @@ jobs:
   check_luts_for_changes:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2

--- a/src/dawe_nrm/api/rva/__init__.py
+++ b/src/dawe_nrm/api/rva/__init__.py
@@ -1,4 +1,3 @@
-import io
 from pathlib import Path
 from typing import Tuple
 


### PR DESCRIPTION
We never set the `python-version` and it was previously working by pure luck. Setting the python version to `3.10` should now fix the workflow typing errors.