### PR TITLE
Fix the label and definition of `condition thresholds`

### DIFF
--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/condition-thresholds.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/condition-thresholds.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/560f42c6-718e-481f-aa6f-8db00ea66d8e>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/condition-threshholds.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/condition-thresholds.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/92d0eaf3-0352-45ba-b173-f82923cdd795> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4da8c123-b886-4881-91b3-1ff6a9b30e3c> ;

--- a/vocab_files/observable_property_concepts/condition-thresholds.ttl
+++ b/vocab_files/observable_property_concepts/condition-thresholds.ttl
@@ -11,9 +11,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 Field Monitoring Protocols Manual: Standardising environmental monitoring and data systems for improved decision
 making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "A summary of the condition threshholds observed in the targeted ecological community." ;
-    skos:prefLabel "condition threshholds" ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/condition-threshholds.ttl"^^xsd:anyURI ;
+    skos:definition "A summary of the condition thresholds observed in the targeted ecological community. For example, see section 1.5.2 in https://www.environment.gov.au/biodiversity/threatened/communities/pubs/152-conservation-advice.pdf" ;
+    skos:prefLabel "condition thresholds" ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/condition-thresholds.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
     tern:hasMethod <https://linked.data.gov.au/def/nrm/4da8c123-b886-4881-91b3-1ff6a9b30e3c> ;
     tern:valueType tern:Text ;


### PR DESCRIPTION
The label should be `condition thresholds` instead of `condition threshholds`.

Added an example of `condition thresholds` in the definition.