### PR TITLE
Linked properties collection and protocol method

### DIFF
--- a/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/basal-area-count.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/basal-area-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/basal-area-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/84b0a152-e6f6-4ea2-b973-04238034bb52> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/29b37ffc-9a41-44f7-889a-bab63b48fa93> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/a7d605e0-7d90-473e-aac0-21cdf380576f> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/basal-area-sweep-hit-type.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/basal-area-sweep-hit-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/basal-area-sweep-hit-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0ba17555-8c8f-435a-b16f-62773561207b> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/84b0a152-e6f6-4ea2-b973-04238034bb52> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/43178892-92a6-434f-9895-340700e299e6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/a7d605e0-7d90-473e-aac0-21cdf380576f> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/circumference-at-breast-height.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/circumference-at-breast-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/circumference-at-breast-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/37d541e6-756f-4248-88cd-ade4775e3b7b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/2d042596-d49a-4139-92f5-dc0f23737e76> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/diameter-at-breast-height-(dbh).ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/diameter-at-breast-height-(dbh).ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/diameter-at-breast-height-(dbh).ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/37d541e6-756f-4248-88cd-ade4775e3b7b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6e1c8b97-3655-4a22-9647-02f2c756e789> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/37d541e6-756f-4248-88cd-ade4775e3b7b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/plant-status.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/plant-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/plant-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b7368a37-a4ac-4c84-8a78-1fb9755ad849> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/37d541e6-756f-4248-88cd-ade4775e3b7b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ddd0c631-bfdd-4b0f-88de-a5eb1a0181c6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/stand-basal-area.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/stand-basal-area.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/stand-basal-area.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/1f93a3e8-4c78-4b08-85a4-6869c9ee17ac> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/37d541e6-756f-4248-88cd-ade4775e3b7b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/f437f23a-7965-4bae-9dc3-2aead06786ec> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/tree-trunk-type.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/tree-trunk-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/full-dbh-measures-protocol/tree-trunk-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/9282400b-56c3-49a9-bb82-87ef74914690> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/37d541e6-756f-4248-88cd-ade4775e3b7b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/3da2a8ca-c0a3-4761-8736-507255eeee68> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/circumference-at-breast-height.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/circumference-at-breast-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/circumference-at-breast-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/558a43c5-80b4-4aab-bfad-246bd2605d2e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/2d042596-d49a-4139-92f5-dc0f23737e76> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/cd83fb3e-d8d3-4502-a618-a0f3f8712b27> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/diameter-at-breast-height-(dbh).ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/diameter-at-breast-height-(dbh).ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/diameter-at-breast-height-(dbh).ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/558a43c5-80b4-4aab-bfad-246bd2605d2e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6e1c8b97-3655-4a22-9647-02f2c756e789> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/cd83fb3e-d8d3-4502-a618-a0f3f8712b27> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/558a43c5-80b4-4aab-bfad-246bd2605d2e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/cd83fb3e-d8d3-4502-a618-a0f3f8712b27> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/plant-status.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/plant-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/plant-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b7368a37-a4ac-4c84-8a78-1fb9755ad849> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/558a43c5-80b4-4aab-bfad-246bd2605d2e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ddd0c631-bfdd-4b0f-88de-a5eb1a0181c6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/cd83fb3e-d8d3-4502-a618-a0f3f8712b27> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/stand-basal-area.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/stand-basal-area.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/stand-basal-area.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/1f93a3e8-4c78-4b08-85a4-6869c9ee17ac> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/558a43c5-80b4-4aab-bfad-246bd2605d2e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/f437f23a-7965-4bae-9dc3-2aead06786ec> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/cd83fb3e-d8d3-4502-a618-a0f3f8712b27> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/tree-trunk-type.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/tree-trunk-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/lite-dbh-measures-protocol/tree-trunk-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/9282400b-56c3-49a9-bb82-87ef74914690> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/558a43c5-80b4-4aab-bfad-246bd2605d2e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/3da2a8ca-c0a3-4761-8736-507255eeee68> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/cd83fb3e-d8d3-4502-a618-a0f3f8712b27> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-array-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-array-protocol/habitat-description.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-array-protocol/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5e7f9234-ce66-46ea-9b5e-d8c692de63c5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1a6953e4-a830-41f8-9cfd-11ead4dd6bc2> ;
     urnp:valueType

--- a/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-fauna-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-fauna-protocol/habitat-description.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-fauna-protocol/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9af8cb76-bf1f-4506-b93a-75152217bf8c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1a6953e4-a830-41f8-9cfd-11ead4dd6bc2> ;
     urnp:valueType

--- a/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-targeted-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-targeted-protocol/habitat-description.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-targeted-protocol/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0942f925-a521-44e8-83e8-f2ff988f8d84> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1a6953e4-a830-41f8-9cfd-11ead4dd6bc2> ;
     urnp:valueType

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-length.ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-length.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-length.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/479f0a22-3de2-4db7-87f7-1bcf4db3d180> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b15f883b-c2e7-408e-8146-3754bbd5693f> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-narrowest-diameter.ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-narrowest-diameter.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-narrowest-diameter.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/479f0a22-3de2-4db7-87f7-1bcf4db3d180> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e73af424-f20d-49b8-81e3-cd30afb5b267> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-per-hectare-(cwd-volume-per-hectare).ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-per-hectare-(cwd-volume-per-hectare).ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-per-hectare-(cwd-volume-per-hectare).ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/479f0a22-3de2-4db7-87f7-1bcf4db3d180> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/74b6493b-8dfe-42f6-acb2-0dda5652cf54> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-percent-cover-(cwd-percent-cover).ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-percent-cover-(cwd-percent-cover).ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-percent-cover-(cwd-percent-cover).ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/479f0a22-3de2-4db7-87f7-1bcf4db3d180> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5370f9a5-c347-4442-b144-e486f11191a8> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-volume-individual-(cwd-volume).ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-volume-individual-(cwd-volume).ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-volume-individual-(cwd-volume).ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/479f0a22-3de2-4db7-87f7-1bcf4db3d180> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/9ce420b8-8070-498c-974f-0eee82f23fd2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-widest-diameter.ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-widest-diameter.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/coarse-woody-debris-widest-diameter.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/479f0a22-3de2-4db7-87f7-1bcf4db3d180> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ee4d10cb-4245-496c-a72c-0696e2014f90> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/cwd-decay-class.ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/cwd-decay-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/plots-measures-protocol/cwd-decay-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b5180d8a-75b6-4bca-9413-0e507e910387> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/479f0a22-3de2-4db7-87f7-1bcf4db3d180> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fa986148-e44a-4cd3-8ac3-17748eb013f3> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-count-(cwd-count).ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-count-(cwd-count).ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-count-(cwd-count).ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/4b676dc6-4143-46df-911e-47625e9dd896> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/acdb15e0-a034-454e-b0e4-8b7546cbb5c7> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-length.ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-length.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-length.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/4b676dc6-4143-46df-911e-47625e9dd896> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b15f883b-c2e7-408e-8146-3754bbd5693f> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-narrowest-diameter.ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-narrowest-diameter.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-narrowest-diameter.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/4b676dc6-4143-46df-911e-47625e9dd896> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e73af424-f20d-49b8-81e3-cd30afb5b267> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-per-hectare-(cwd-volume-per-hectare).ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-per-hectare-(cwd-volume-per-hectare).ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-per-hectare-(cwd-volume-per-hectare).ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/4b676dc6-4143-46df-911e-47625e9dd896> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/74b6493b-8dfe-42f6-acb2-0dda5652cf54> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-percent-cover-(cwd-percent-cover).ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-percent-cover-(cwd-percent-cover).ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-percent-cover-(cwd-percent-cover).ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/4b676dc6-4143-46df-911e-47625e9dd896> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5370f9a5-c347-4442-b144-e486f11191a8> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-volume-individual-(cwd-volume).ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-volume-individual-(cwd-volume).ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-volume-individual-(cwd-volume).ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/4b676dc6-4143-46df-911e-47625e9dd896> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/9ce420b8-8070-498c-974f-0eee82f23fd2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-widest-diameter.ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-widest-diameter.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/coarse-woody-debris-widest-diameter.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/4b676dc6-4143-46df-911e-47625e9dd896> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ee4d10cb-4245-496c-a72c-0696e2014f90> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/cwd-decay-class.ttl
+++ b/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/cwd-decay-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/coarse-woody-debris/transects-measures-protocol/cwd-decay-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b5180d8a-75b6-4bca-9413-0e507e910387> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/4b676dc6-4143-46df-911e-47625e9dd896> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fa986148-e44a-4cd3-8ac3-17748eb013f3> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/canopy-health.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/canopy-health.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/canopy-health.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/d0a31d21-b475-490e-a8d6-fbe374fc7391> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/dieback-from-disease.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/dieback-from-disease.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/dieback-from-disease.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0685299e-d22a-4efa-a507-a7614e58a500> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/epicormic-growth.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/epicormic-growth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/epicormic-growth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/cacfba72-ae93-4f92-9cc3-bf656d7ab5f0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/galls-and-lerps.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/galls-and-lerps.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/galls-and-lerps.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/28131f08-1ae4-422f-99cb-3b5bafc7761d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/grazing.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/grazing.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/grazing.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/cd905dda-06df-4f0e-85eb-b50f9ed2af91> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/growth-stage.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/growth-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/growth-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/096e018a-fb8f-4ba1-9fdc-302164e57682> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fcfda2f7-84f0-4c26-9f80-c051d129a094> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/insect-damage.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/insect-damage.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/insect-damage.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/33e79578-0946-4f21-9607-ca501e1500c7> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/large-tree-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/large-tree-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/large-tree-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/1fc43da5-004d-4258-bd33-8ffc9e2e8cba> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/leaf-litter-depth.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/leaf-litter-depth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/leaf-litter-depth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e6ed6e58-5916-4d31-9ed5-109ab3436fce> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/f6af2c5e-d193-4337-b845-44550f661854> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/mistletoe-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/mistletoe-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/mistletoe-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6a1d703f-6622-4804-8b78-4c2ac93c97ba> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/plant-height.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/plant-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/plant-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9da717-6c8e-4194-9385-c995d54702e4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/seedling-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/seedling-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/seedling-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b6a5d847-0698-4cce-8a5e-f2719e142208> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/small-tree-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/small-tree-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/small-tree-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/48370fb2-ab58-4f19-8d99-6d005f61538a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/vegetation-diameter-class.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/vegetation-diameter-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/vegetation-diameter-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/fe0b8990-dc4c-4fc7-85e8-be08da5721a0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/84369f9d-bcf3-4054-b200-797c8ae3064f> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/vegetation-health.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/vegetation-health.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/vegetation-health.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/785f818c-0c8c-480b-b8e5-43ea9fda70f0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7d4eaa80-0f2a-4828-886e-34cd5a4e2746> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/vertebrate-pest-presence-evidence.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/vertebrate-pest-presence-evidence.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/vertebrate-pest-presence-evidence.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/69638c57-1c38-47e1-8bae-c821411c3a30> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/adc24cd3-b652-4696-bca0-b881b0111cdb> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/vertebrate-pest-type.ttl
+++ b/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/vertebrate-pest-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/condition-point-intercept-protocol/vertebrate-pest-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/579449ad-4cea-4272-afa3-67f207941fb1> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/13dec53e-1062-4060-9281-f133c8269afb> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/81bb6166-e757-4e2d-99ad-bd13b12c3d02> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/85d5f75c-776f-44a3-abe6-e71c695f1754> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/canopy-health.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/canopy-health.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/canopy-health.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/d0a31d21-b475-490e-a8d6-fbe374fc7391> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/canopy-health.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/canopy-health.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/6355121c-4244-4860-b308-655c8c8605e5>
+<https://linked.data.gov.au/def/nrm/dd7036c3-a76b-4036-a58e-5dd5b69d725e>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/plant-height.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/canopy-health.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9da717-6c8e-4194-9385-c995d54702e4> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/d0a31d21-b475-490e-a8d6-fbe374fc7391> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Float ;
 .

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/collection.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/collection.ttl
@@ -28,6 +28,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         <https://linked.data.gov.au/def/nrm/f6af2c5e-d193-4337-b845-44550f661854> ,
         <https://linked.data.gov.au/def/nrm/fcfda2f7-84f0-4c26-9f80-c051d129a094> ;
     skos:prefLabel "Condition - Vegetation age class structure (sub-plot) Observable Properties" ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/collection.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/collection.ttl"^^xsd:anyURI ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/dieback-from-disease.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/dieback-from-disease.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/dieback-from-disease.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0685299e-d22a-4efa-a507-a7614e58a500> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/dieback-from-disease.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/dieback-from-disease.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/2a5e528e-eaac-4197-82c2-e2def788520a>
+<https://linked.data.gov.au/def/nrm/0663cea1-ea1f-4b96-8aba-bcadb1a8d937>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/grazing.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/dieback-from-disease.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/cd905dda-06df-4f0e-85eb-b50f9ed2af91> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/0685299e-d22a-4efa-a507-a7614e58a500> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Boolean ;
 .

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/epicormic-growth.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/epicormic-growth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/epicormic-growth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/cacfba72-ae93-4f92-9cc3-bf656d7ab5f0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/epicormic-growth.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/epicormic-growth.ttl
@@ -4,12 +4,12 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/9b1dfb5a-59f6-4b76-b8fd-6bdf021e170f>
+<https://linked.data.gov.au/def/nrm/9080cc50-faff-49eb-b14c-8546939d3b10>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/large-tree-count.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/epicormic-growth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/1fc43da5-004d-4258-bd33-8ffc9e2e8cba> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/cacfba72-ae93-4f92-9cc3-bf656d7ab5f0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
-    urnp:valueType tern:Integer ;
+    urnp:valueType tern:Boolean ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/field-species-name.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/3e9477c3-bd7b-4c6f-9f10-7c9806d48f72>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/field-species-name.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/galls-and-lerps.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/galls-and-lerps.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/7b902014-96db-441c-a7fb-ee5f7c03b4e1>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/galls-and-lerps.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/galls-and-lerps.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/28131f08-1ae4-422f-99cb-3b5bafc7761d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/galls-and-lerps.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/galls-and-lerps.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/galls-and-lerps.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/28131f08-1ae4-422f-99cb-3b5bafc7761d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/grazing.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/grazing.ttl
@@ -4,12 +4,12 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/1993bb31-c1d4-4e3e-b2e1-cb55697d452b>
+<https://linked.data.gov.au/def/nrm/2a5e528e-eaac-4197-82c2-e2def788520a>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/mistletoe-count.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/grazing.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/6a1d703f-6622-4804-8b78-4c2ac93c97ba> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/cd905dda-06df-4f0e-85eb-b50f9ed2af91> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
-    urnp:valueType tern:Integer ;
+    urnp:valueType tern:Boolean ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/grazing.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/grazing.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/grazing.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/cd905dda-06df-4f0e-85eb-b50f9ed2af91> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/growth-stage.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/growth-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/growth-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/096e018a-fb8f-4ba1-9fdc-302164e57682> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fcfda2f7-84f0-4c26-9f80-c051d129a094> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/growth-stage.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/growth-stage.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/3a8bfcc4-4a86-43dc-87cd-256f4491397f>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/growth-stage.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/growth-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/096e018a-fb8f-4ba1-9fdc-302164e57682> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fcfda2f7-84f0-4c26-9f80-c051d129a094> ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/insect-damage.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/insect-damage.ttl
@@ -4,12 +4,12 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/dd7036c3-a76b-4036-a58e-5dd5b69d725e>
+<https://linked.data.gov.au/def/nrm/6764d287-caf8-440c-b55b-dfb5bc35b415>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/canopy-health.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/insect-damage.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/d0a31d21-b475-490e-a8d6-fbe374fc7391> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/33e79578-0946-4f21-9607-ca501e1500c7> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
-    urnp:valueType tern:Float ;
+    urnp:valueType tern:Boolean ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/insect-damage.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/insect-damage.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/insect-damage.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/33e79578-0946-4f21-9607-ca501e1500c7> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/large-tree-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/large-tree-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/large-tree-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/1fc43da5-004d-4258-bd33-8ffc9e2e8cba> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/large-tree-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/large-tree-count.ttl
@@ -4,12 +4,12 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/0663cea1-ea1f-4b96-8aba-bcadb1a8d937>
+<https://linked.data.gov.au/def/nrm/9b1dfb5a-59f6-4b76-b8fd-6bdf021e170f>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/dieback-from-disease.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/large-tree-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/0685299e-d22a-4efa-a507-a7614e58a500> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/1fc43da5-004d-4258-bd33-8ffc9e2e8cba> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
-    urnp:valueType tern:Boolean ;
+    urnp:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/leaf-litter-depth.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/leaf-litter-depth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/leaf-litter-depth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e6ed6e58-5916-4d31-9ed5-109ab3436fce> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/f6af2c5e-d193-4337-b845-44550f661854> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/leaf-litter-depth.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/leaf-litter-depth.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/e9487c93-3136-4f9c-aab0-835d9d54a766>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/leaf-litter-depth.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/leaf-litter-depth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e6ed6e58-5916-4d31-9ed5-109ab3436fce> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/f6af2c5e-d193-4337-b845-44550f661854> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/mistletoe-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/mistletoe-count.ttl
@@ -4,12 +4,12 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/6764d287-caf8-440c-b55b-dfb5bc35b415>
+<https://linked.data.gov.au/def/nrm/1993bb31-c1d4-4e3e-b2e1-cb55697d452b>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/insect-damage.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/mistletoe-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/33e79578-0946-4f21-9607-ca501e1500c7> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/6a1d703f-6622-4804-8b78-4c2ac93c97ba> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
-    urnp:valueType tern:Boolean ;
+    urnp:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/mistletoe-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/mistletoe-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/mistletoe-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6a1d703f-6622-4804-8b78-4c2ac93c97ba> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/plant-height.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/plant-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/plant-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9da717-6c8e-4194-9385-c995d54702e4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/plant-height.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/plant-height.ttl
@@ -4,12 +4,12 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/9be418b2-6701-4593-8b83-6218e6f5d42b>
+<https://linked.data.gov.au/def/nrm/6355121c-4244-4860-b308-655c8c8605e5>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/seedling-count.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/plant-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/b6a5d847-0698-4cce-8a5e-f2719e142208> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9da717-6c8e-4194-9385-c995d54702e4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
-    urnp:valueType tern:Integer ;
+    urnp:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/seedling-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/seedling-count.ttl
@@ -4,12 +4,12 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/9080cc50-faff-49eb-b14c-8546939d3b10>
+<https://linked.data.gov.au/def/nrm/9be418b2-6701-4593-8b83-6218e6f5d42b>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/epicormic-growth.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/seedling-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/cacfba72-ae93-4f92-9cc3-bf656d7ab5f0> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/b6a5d847-0698-4cce-8a5e-f2719e142208> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
-    urnp:valueType tern:Boolean ;
+    urnp:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/seedling-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/seedling-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/seedling-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b6a5d847-0698-4cce-8a5e-f2719e142208> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/small-tree-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/small-tree-count.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/6d4e3226-7a0f-4255-b407-82bbd29885b3>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/small-tree-count.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/small-tree-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/48370fb2-ab58-4f19-8d99-6d005f61538a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/small-tree-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/small-tree-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/small-tree-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/48370fb2-ab58-4f19-8d99-6d005f61538a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vegetation-diameter-class.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vegetation-diameter-class.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/a565b504-d63a-402a-85fe-e08dc4613dba>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/vegetation-diameter-class.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vegetation-diameter-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/fe0b8990-dc4c-4fc7-85e8-be08da5721a0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/84369f9d-bcf3-4054-b200-797c8ae3064f> ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vegetation-diameter-class.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vegetation-diameter-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vegetation-diameter-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/fe0b8990-dc4c-4fc7-85e8-be08da5721a0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/84369f9d-bcf3-4054-b200-797c8ae3064f> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vegetation-health.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vegetation-health.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vegetation-health.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/785f818c-0c8c-480b-b8e5-43ea9fda70f0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7d4eaa80-0f2a-4828-886e-34cd5a4e2746> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vegetation-health.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vegetation-health.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/23306d6a-340d-47d6-a6cb-3f56cb9379a6>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/vegetation-health.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vegetation-health.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/785f818c-0c8c-480b-b8e5-43ea9fda70f0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7d4eaa80-0f2a-4828-886e-34cd5a4e2746> ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vertebrate-pest-presence-evidence.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vertebrate-pest-presence-evidence.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vertebrate-pest-presence-evidence.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/69638c57-1c38-47e1-8bae-c821411c3a30> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/adc24cd3-b652-4696-bca0-b881b0111cdb> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vertebrate-pest-presence-evidence.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vertebrate-pest-presence-evidence.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/b53cb766-88d1-4d0e-8a73-7aaa6b221cc2>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/vertebrate-pest-presence-evidence.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vertebrate-pest-presence-evidence.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/69638c57-1c38-47e1-8bae-c821411c3a30> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/adc24cd3-b652-4696-bca0-b881b0111cdb> ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vertebrate-pest-type.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vertebrate-pest-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vertebrate-pest-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/579449ad-4cea-4272-afa3-67f207941fb1> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/13dec53e-1062-4060-9281-f133c8269afb> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/39b279f5-f026-4fe4-8c01-d1c5d3af6f3c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/85d5f75c-776f-44a3-abe6-e71c695f1754> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vertebrate-pest-type.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vertebrate-pest-type.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/fd65aedc-283b-4f16-b60d-fc1f34c05da1>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-(sub-plot)-protocol/vertebrate-pest-type.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vegetation-age-class-structure-sub-plot-protocol/vertebrate-pest-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/579449ad-4cea-4272-afa3-67f207941fb1> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/13dec53e-1062-4060-9281-f133c8269afb> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/85d5f75c-776f-44a3-abe6-e71c695f1754> ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/canopy-health.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/canopy-health.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/canopy-health.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/d0a31d21-b475-490e-a8d6-fbe374fc7391> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/canopy-health.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/canopy-health.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/4b7e0045-c18c-4e76-9f5c-626d022151bd>
+<https://linked.data.gov.au/def/nrm/de3fb35d-f22b-41e9-9d5b-8637bc90ee5e>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/plant-height.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/canopy-health.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9da717-6c8e-4194-9385-c995d54702e4> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/d0a31d21-b475-490e-a8d6-fbe374fc7391> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Float ;
 .

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/collection.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/collection.ttl
@@ -28,6 +28,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         <https://linked.data.gov.au/def/nrm/f6af2c5e-d193-4337-b845-44550f661854> ,
         <https://linked.data.gov.au/def/nrm/fcfda2f7-84f0-4c26-9f80-c051d129a094> ;
     skos:prefLabel "Condition - Vertebrate pest presence (plot) Observable Properties" ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/collection.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/collection.ttl"^^xsd:anyURI ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/dieback-from-disease.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/dieback-from-disease.ttl
@@ -4,12 +4,12 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/7f5db6f3-15fc-471b-a1f7-0b1cf45c41fa>
+<https://linked.data.gov.au/def/nrm/2ad7f826-57f1-4578-8dfa-9e4538f684d7>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/seedling-count.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/dieback-from-disease.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/b6a5d847-0698-4cce-8a5e-f2719e142208> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/0685299e-d22a-4efa-a507-a7614e58a500> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
-    urnp:valueType tern:Integer ;
+    urnp:valueType tern:Boolean ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/dieback-from-disease.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/dieback-from-disease.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/dieback-from-disease.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0685299e-d22a-4efa-a507-a7614e58a500> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/epicormic-growth.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/epicormic-growth.ttl
@@ -4,12 +4,12 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/2cf06de7-ae84-4c9d-8253-520f8e8993d0>
+<https://linked.data.gov.au/def/nrm/22c951ea-f4df-414a-8e22-c8ca3a18b1e2>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/small-tree-count.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/epicormic-growth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/48370fb2-ab58-4f19-8d99-6d005f61538a> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/cacfba72-ae93-4f92-9cc3-bf656d7ab5f0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
-    urnp:valueType tern:Integer ;
+    urnp:valueType tern:Boolean ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/epicormic-growth.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/epicormic-growth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/epicormic-growth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/cacfba72-ae93-4f92-9cc3-bf656d7ab5f0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/field-species-name.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/64da3790-0f31-41aa-9d1b-6daaa4c0e1f3>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/field-species-name.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/galls-and-lerps.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/galls-and-lerps.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/d9db7d26-d7cf-4fdb-b229-a7c318ce6ce0>
+<https://linked.data.gov.au/def/nrm/e13e562b-e8e6-4fed-b38b-11a4123bd25d>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/insect-damage.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/galls-and-lerps.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/33e79578-0946-4f21-9607-ca501e1500c7> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/28131f08-1ae4-422f-99cb-3b5bafc7761d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Boolean ;
 .

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/galls-and-lerps.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/galls-and-lerps.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/galls-and-lerps.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/28131f08-1ae4-422f-99cb-3b5bafc7761d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/grazing.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/grazing.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/22c951ea-f4df-414a-8e22-c8ca3a18b1e2>
+<https://linked.data.gov.au/def/nrm/06fe3c19-932a-470a-9f3e-d5afe5bc1ee2>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/epicormic-growth.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/grazing.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/cacfba72-ae93-4f92-9cc3-bf656d7ab5f0> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/cd905dda-06df-4f0e-85eb-b50f9ed2af91> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Boolean ;
 .

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/grazing.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/grazing.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/grazing.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/cd905dda-06df-4f0e-85eb-b50f9ed2af91> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/growth-stage.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/growth-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/growth-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/096e018a-fb8f-4ba1-9fdc-302164e57682> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fcfda2f7-84f0-4c26-9f80-c051d129a094> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/growth-stage.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/growth-stage.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/3b062cb4-e74b-46ec-a960-151740679f27>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/growth-stage.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/growth-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/096e018a-fb8f-4ba1-9fdc-302164e57682> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fcfda2f7-84f0-4c26-9f80-c051d129a094> ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/insect-damage.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/insect-damage.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/insect-damage.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/33e79578-0946-4f21-9607-ca501e1500c7> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/insect-damage.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/insect-damage.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/2ad7f826-57f1-4578-8dfa-9e4538f684d7>
+<https://linked.data.gov.au/def/nrm/d9db7d26-d7cf-4fdb-b229-a7c318ce6ce0>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/dieback-from-disease.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/insect-damage.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/0685299e-d22a-4efa-a507-a7614e58a500> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/33e79578-0946-4f21-9607-ca501e1500c7> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Boolean ;
 .

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/large-tree-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/large-tree-count.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/41889239-8cb8-4503-bd64-1561fff5bc62>
+<https://linked.data.gov.au/def/nrm/a9103f95-5850-42a6-b53b-c0d377376d53>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/mistletoe-count.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/large-tree-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/6a1d703f-6622-4804-8b78-4c2ac93c97ba> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/1fc43da5-004d-4258-bd33-8ffc9e2e8cba> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Integer ;
 .

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/large-tree-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/large-tree-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/large-tree-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/1fc43da5-004d-4258-bd33-8ffc9e2e8cba> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/leaf-litter-depth.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/leaf-litter-depth.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/ed3ad736-934c-4f26-a0c4-d40ee80b0243>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/leaf-litter-depth.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/leaf-litter-depth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e6ed6e58-5916-4d31-9ed5-109ab3436fce> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/f6af2c5e-d193-4337-b845-44550f661854> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/leaf-litter-depth.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/leaf-litter-depth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/leaf-litter-depth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e6ed6e58-5916-4d31-9ed5-109ab3436fce> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/f6af2c5e-d193-4337-b845-44550f661854> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/mistletoe-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/mistletoe-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/mistletoe-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6a1d703f-6622-4804-8b78-4c2ac93c97ba> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/mistletoe-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/mistletoe-count.ttl
@@ -4,12 +4,12 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/06fe3c19-932a-470a-9f3e-d5afe5bc1ee2>
+<https://linked.data.gov.au/def/nrm/41889239-8cb8-4503-bd64-1561fff5bc62>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/grazing.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/mistletoe-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/cd905dda-06df-4f0e-85eb-b50f9ed2af91> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/6a1d703f-6622-4804-8b78-4c2ac93c97ba> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
-    urnp:valueType tern:Boolean ;
+    urnp:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/plant-height.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/plant-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/plant-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9da717-6c8e-4194-9385-c995d54702e4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/plant-height.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/plant-height.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/de3fb35d-f22b-41e9-9d5b-8637bc90ee5e>
+<https://linked.data.gov.au/def/nrm/4b7e0045-c18c-4e76-9f5c-626d022151bd>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/canopy-health.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/plant-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/d0a31d21-b475-490e-a8d6-fbe374fc7391> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9da717-6c8e-4194-9385-c995d54702e4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Float ;
 .

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/seedling-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/seedling-count.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/a9103f95-5850-42a6-b53b-c0d377376d53>
+<https://linked.data.gov.au/def/nrm/7f5db6f3-15fc-471b-a1f7-0b1cf45c41fa>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/large-tree-count.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/seedling-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/1fc43da5-004d-4258-bd33-8ffc9e2e8cba> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/b6a5d847-0698-4cce-8a5e-f2719e142208> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Integer ;
 .

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/seedling-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/seedling-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/seedling-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b6a5d847-0698-4cce-8a5e-f2719e142208> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/small-tree-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/small-tree-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/small-tree-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/48370fb2-ab58-4f19-8d99-6d005f61538a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/small-tree-count.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/small-tree-count.ttl
@@ -4,12 +4,12 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/e13e562b-e8e6-4fed-b38b-11a4123bd25d>
+<https://linked.data.gov.au/def/nrm/2cf06de7-ae84-4c9d-8253-520f8e8993d0>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/galls-and-lerps.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/small-tree-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/28131f08-1ae4-422f-99cb-3b5bafc7761d> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/48370fb2-ab58-4f19-8d99-6d005f61538a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
-    urnp:valueType tern:Boolean ;
+    urnp:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vegetation-diameter-class.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vegetation-diameter-class.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/2a28398e-8bc2-4796-bcf0-3cfe547cb23e>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/vegetation-diameter-class.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vegetation-diameter-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/fe0b8990-dc4c-4fc7-85e8-be08da5721a0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/84369f9d-bcf3-4054-b200-797c8ae3064f> ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vegetation-diameter-class.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vegetation-diameter-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vegetation-diameter-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/fe0b8990-dc4c-4fc7-85e8-be08da5721a0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/84369f9d-bcf3-4054-b200-797c8ae3064f> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vegetation-health.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vegetation-health.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vegetation-health.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/785f818c-0c8c-480b-b8e5-43ea9fda70f0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7d4eaa80-0f2a-4828-886e-34cd5a4e2746> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vegetation-health.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vegetation-health.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/9a18d82f-5faf-4ecc-a6b6-f2fcb679651d>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/vegetation-health.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vegetation-health.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/785f818c-0c8c-480b-b8e5-43ea9fda70f0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7d4eaa80-0f2a-4828-886e-34cd5a4e2746> ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vertebrate-pest-presence-evidence.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vertebrate-pest-presence-evidence.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vertebrate-pest-presence-evidence.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/69638c57-1c38-47e1-8bae-c821411c3a30> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/adc24cd3-b652-4696-bca0-b881b0111cdb> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vertebrate-pest-presence-evidence.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vertebrate-pest-presence-evidence.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/72287542-af6c-40ba-9dd3-67a9f60e1d2d>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/vertebrate-pest-presence-evidence.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vertebrate-pest-presence-evidence.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/69638c57-1c38-47e1-8bae-c821411c3a30> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/adc24cd3-b652-4696-bca0-b881b0111cdb> ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vertebrate-pest-type.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vertebrate-pest-type.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/9fb12f46-95dd-4ebb-9e80-b5f246deb1c2>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-(plot)-protocol/vertebrate-pest-type.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vertebrate-pest-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/579449ad-4cea-4272-afa3-67f207941fb1> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/13dec53e-1062-4060-9281-f133c8269afb> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/85d5f75c-776f-44a3-abe6-e71c695f1754> ;

--- a/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vertebrate-pest-type.ttl
+++ b/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vertebrate-pest-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/condition/vertebrate-pest-presence-plot-protocol/vertebrate-pest-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/579449ad-4cea-4272-afa3-67f207941fb1> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/13dec53e-1062-4060-9281-f133c8269afb> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7746f2f1-e8bf-450d-972a-9c1985714cef> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/85d5f75c-776f-44a3-abe6-e71c695f1754> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/cover/full-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/cover/full-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/full-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc009349-c1d0-4000-a5d0-1b1c18c3ea0e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/576f634e-2706-4f18-b561-0636d4c007d0> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/cover/full-protocol/growth-form.ttl
+++ b/vocab_files/observable_properties_by_module/cover/full-protocol/growth-form.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/full-protocol/growth-form.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d0fc07a7-3ec9-45ed-8850-885a32828d3c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc009349-c1d0-4000-a5d0-1b1c18c3ea0e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dd1769b9-c475-4732-915c-9b890a8d5f65> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/576f634e-2706-4f18-b561-0636d4c007d0> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/cover/full-protocol/in-canopy-sky.ttl
+++ b/vocab_files/observable_properties_by_module/cover/full-protocol/in-canopy-sky.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/full-protocol/in-canopy-sky.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc009349-c1d0-4000-a5d0-1b1c18c3ea0e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/85bdd25a-fa08-49de-9f0b-98895cb79aa6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/576f634e-2706-4f18-b561-0636d4c007d0> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/cover/full-protocol/substrate-type.ttl
+++ b/vocab_files/observable_properties_by_module/cover/full-protocol/substrate-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/full-protocol/substrate-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b061d7db-a608-4062-96d4-b367d6d9a792> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc009349-c1d0-4000-a5d0-1b1c18c3ea0e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/75f55bf0-6972-42ba-ad46-7e24f91e8f6a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/576f634e-2706-4f18-b561-0636d4c007d0> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/cover/full-protocol/uppermost-height.ttl
+++ b/vocab_files/observable_properties_by_module/cover/full-protocol/uppermost-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/full-protocol/uppermost-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc009349-c1d0-4000-a5d0-1b1c18c3ea0e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/823263e6-4bc9-4c98-94de-74a509aef47c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/576f634e-2706-4f18-b561-0636d4c007d0> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/cover/lite-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/cover/lite-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/lite-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc9aa42b-f908-4c73-adb2-d1847eee4ea3> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/aa1525f9-c3f2-4f7d-98cc-6a7d3aec9d8a> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/cover/lite-protocol/growth-form.ttl
+++ b/vocab_files/observable_properties_by_module/cover/lite-protocol/growth-form.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/lite-protocol/growth-form.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d0fc07a7-3ec9-45ed-8850-885a32828d3c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc9aa42b-f908-4c73-adb2-d1847eee4ea3> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dd1769b9-c475-4732-915c-9b890a8d5f65> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/aa1525f9-c3f2-4f7d-98cc-6a7d3aec9d8a> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/cover/lite-protocol/in-canopy-sky.ttl
+++ b/vocab_files/observable_properties_by_module/cover/lite-protocol/in-canopy-sky.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/lite-protocol/in-canopy-sky.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc9aa42b-f908-4c73-adb2-d1847eee4ea3> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/85bdd25a-fa08-49de-9f0b-98895cb79aa6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/aa1525f9-c3f2-4f7d-98cc-6a7d3aec9d8a> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/cover/lite-protocol/substrate-type.ttl
+++ b/vocab_files/observable_properties_by_module/cover/lite-protocol/substrate-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/lite-protocol/substrate-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b061d7db-a608-4062-96d4-b367d6d9a792> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc9aa42b-f908-4c73-adb2-d1847eee4ea3> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/75f55bf0-6972-42ba-ad46-7e24f91e8f6a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/aa1525f9-c3f2-4f7d-98cc-6a7d3aec9d8a> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/cover/lite-protocol/uppermost-height.ttl
+++ b/vocab_files/observable_properties_by_module/cover/lite-protocol/uppermost-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/lite-protocol/uppermost-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc9aa42b-f908-4c73-adb2-d1847eee4ea3> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/823263e6-4bc9-4c98-94de-74a509aef47c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/aa1525f9-c3f2-4f7d-98cc-6a7d3aec9d8a> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/fire/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/fire/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/fire/fire-substrate-type.ttl
+++ b/vocab_files/observable_properties_by_module/fire/fire-substrate-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/fire-substrate-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c7a0692c-113c-4593-ae04-5e49aba70fdf> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/56efb36f-d3bc-475d-80d3-990f910f8488> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/fire/growth-form.ttl
+++ b/vocab_files/observable_properties_by_module/fire/growth-form.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/growth-form.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d0fc07a7-3ec9-45ed-8850-885a32828d3c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dd1769b9-c475-4732-915c-9b890a8d5f65> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/fire/in-canopy-sky.ttl
+++ b/vocab_files/observable_properties_by_module/fire/in-canopy-sky.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/in-canopy-sky.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/85bdd25a-fa08-49de-9f0b-98895cb79aa6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/fire/plant-height.ttl
+++ b/vocab_files/observable_properties_by_module/fire/plant-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/plant-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9da717-6c8e-4194-9385-c995d54702e4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/fire/plant-regenerating-height.ttl
+++ b/vocab_files/observable_properties_by_module/fire/plant-regenerating-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/plant-regenerating-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/936f6c7d-9432-41d2-8214-00ed64e8f0c4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/fire/plant-status.ttl
+++ b/vocab_files/observable_properties_by_module/fire/plant-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/plant-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b7368a37-a4ac-4c84-8a78-1fb9755ad849> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ddd0c631-bfdd-4b0f-88de-a5eb1a0181c6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/fire/plot-burned-status.ttl
+++ b/vocab_files/observable_properties_by_module/fire/plot-burned-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/plot-burned-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/5662a7dd-c1da-4659-8290-a1e6e42c879f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/8eb830f7-a0ec-42d6-8170-dbe2f4d56db2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/fire/regeneration-status.ttl
+++ b/vocab_files/observable_properties_by_module/fire/regeneration-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/regeneration-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/a1b8fc00-5d5f-40f8-a7e1-0b09d4bbba4b> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/50239f29-a693-49ef-98e8-4ee11d1758ea> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/fire/soil-char-depth.ttl
+++ b/vocab_files/observable_properties_by_module/fire/soil-char-depth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/soil-char-depth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/98e8d72d-f361-41ed-af9d-6e7f90c1dfce> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/d88be090-97b9-40a1-9251-65f5c945b50e> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/fire/species-intercepted.ttl
+++ b/vocab_files/observable_properties_by_module/fire/species-intercepted.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/species-intercepted.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/20c219f2-1526-4365-8f77-569cec5f1731> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/fire/substrate-type.ttl
+++ b/vocab_files/observable_properties_by_module/fire/substrate-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/substrate-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b061d7db-a608-4062-96d4-b367d6d9a792> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/75f55bf0-6972-42ba-ad46-7e24f91e8f6a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/fire/tree-trunk-char-height.ttl
+++ b/vocab_files/observable_properties_by_module/fire/tree-trunk-char-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/tree-trunk-char-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/3a2b344c-07b5-4536-8db3-06b73bc0e263> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/floristics/full-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/floristics/full-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/floristics/full-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/669b2433-75d3-4639-a3b0-73cd1f4dbd45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/35175f0d-bdd7-4e32-908f-17f7239e78fa> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/floristics/full-protocol/growth-form.ttl
+++ b/vocab_files/observable_properties_by_module/floristics/full-protocol/growth-form.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/floristics/full-protocol/growth-form.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d0fc07a7-3ec9-45ed-8850-885a32828d3c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/669b2433-75d3-4639-a3b0-73cd1f4dbd45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dd1769b9-c475-4732-915c-9b890a8d5f65> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/35175f0d-bdd7-4e32-908f-17f7239e78fa> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/floristics/lite-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/floristics/lite-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/floristics/lite-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/44942870-743d-4989-aa40-581bdc84f078> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bc2ba93e-43f9-425f-83cd-bbf5c422bdf8> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/floristics/lite-protocol/growth-form.ttl
+++ b/vocab_files/observable_properties_by_module/floristics/lite-protocol/growth-form.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/floristics/lite-protocol/growth-form.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d0fc07a7-3ec9-45ed-8850-885a32828d3c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/44942870-743d-4989-aa40-581bdc84f078> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dd1769b9-c475-4732-915c-9b890a8d5f65> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/bc2ba93e-43f9-425f-83cd-bbf5c422bdf8> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/habitat-description.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2d955edb-ab22-4101-bc72-b5899d901fd7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e76e99ef-de1d-4387-9b2e-3455b9f9ff78> ;
     urnp:valueType

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/weather-site-cloud-cover.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/weather-site-cloud-cover.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/weather-site-cloud-cover.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b001aab8-d5c2-4268-a750-bed499386691> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2d955edb-ab22-4101-bc72-b5899d901fd7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/111a2971-f7c3-4d9d-b079-d9afa0bcc8b0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e76e99ef-de1d-4387-9b2e-3455b9f9ff78> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/weather-site-precipitation.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/weather-site-precipitation.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/weather-site-precipitation.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/36e4cff5-f238-45e3-85ec-bdd0973f09d7> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2d955edb-ab22-4101-bc72-b5899d901fd7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b7e7f67b-d983-4167-baca-57cab6dd89a2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e76e99ef-de1d-4387-9b2e-3455b9f9ff78> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/weather-site-temperature.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/weather-site-temperature.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/weather-site-temperature.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/cd1530af-09a6-4666-98d5-580c0e65cf10> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2d955edb-ab22-4101-bc72-b5899d901fd7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a30248c3-33ce-4ffe-8130-7b03aa4e5322> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e76e99ef-de1d-4387-9b2e-3455b9f9ff78> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/weather-site-wind.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/weather-site-wind.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/weather-site-wind.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0fb03c4e-ad42-445a-a2c5-688d7d7effd8> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2d955edb-ab22-4101-bc72-b5899d901fd7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e8f03cc8-33a3-4c2f-9a0d-95a40c34523d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e76e99ef-de1d-4387-9b2e-3455b9f9ff78> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/area-of-litter-sampled.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/area-of-litter-sampled.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/area-of-litter-sampled.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e6ed6e58-5916-4d31-9ed5-109ab3436fce> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/b29538e9-1118-45c5-88d5-ba1738b57940> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/87709af7-edbf-43a8-a507-d6e5b6bd1b58> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/estimate-volume-of-leaf-litter-extraction.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/estimate-volume-of-leaf-litter-extraction.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/estimate-volume-of-leaf-litter-extraction.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e6ed6e58-5916-4d31-9ed5-109ab3436fce> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/b29538e9-1118-45c5-88d5-ba1738b57940> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e2f04c7-a576-4565-8e4f-2d53a5e26ef7> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/estimate-volume-of-leaf-litter.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/estimate-volume-of-leaf-litter.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/estimate-volume-of-leaf-litter.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e6ed6e58-5916-4d31-9ed5-109ab3436fce> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/b29538e9-1118-45c5-88d5-ba1738b57940> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/4ad7d58a-543b-46b5-83c5-fa87dd8ce1ff> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/habitat-description.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/b29538e9-1118-45c5-88d5-ba1738b57940> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     urnp:valueType

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/litter-depth.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/litter-depth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/litter-depth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e6ed6e58-5916-4d31-9ed5-109ab3436fce> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/b29538e9-1118-45c5-88d5-ba1738b57940> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/94b5aec9-33cd-435e-a861-f10f70a1006c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/soil-surface-temperature.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/soil-surface-temperature.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/soil-surface-temperature.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/b29538e9-1118-45c5-88d5-ba1738b57940> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/375e39af-79d9-4b69-8349-fcc34bf37b68> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/soil-type.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/soil-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/soil-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/ecdcb81a-cbe9-4113-b9e9-422a0e6c751f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/98e8d72d-f361-41ed-af9d-6e7f90c1dfce> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/b29538e9-1118-45c5-88d5-ba1738b57940> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/1d5a5f27-0e18-4685-a686-1924684d0d59> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/weather-site-cloud-cover.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/weather-site-cloud-cover.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/weather-site-cloud-cover.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b001aab8-d5c2-4268-a750-bed499386691> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/b29538e9-1118-45c5-88d5-ba1738b57940> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/111a2971-f7c3-4d9d-b079-d9afa0bcc8b0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/weather-site-precipitation.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/weather-site-precipitation.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/weather-site-precipitation.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/36e4cff5-f238-45e3-85ec-bdd0973f09d7> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/b29538e9-1118-45c5-88d5-ba1738b57940> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b7e7f67b-d983-4167-baca-57cab6dd89a2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/weather-site-temperature.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/weather-site-temperature.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/weather-site-temperature.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/cd1530af-09a6-4666-98d5-580c0e65cf10> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/b29538e9-1118-45c5-88d5-ba1738b57940> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a30248c3-33ce-4ffe-8130-7b03aa4e5322> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/weather-site-wind.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/weather-site-wind.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/weather-site-wind.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0fb03c4e-ad42-445a-a2c5-688d7d7effd8> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/b29538e9-1118-45c5-88d5-ba1738b57940> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e8f03cc8-33a3-4c2f-9a0d-95a40c34523d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/collection.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/collection.ttl
@@ -14,6 +14,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         <https://linked.data.gov.au/def/nrm/b7e7f67b-d983-4167-baca-57cab6dd89a2> ,
         <https://linked.data.gov.au/def/nrm/e8f03cc8-33a3-4c2f-9a0d-95a40c34523d> ;
     skos:prefLabel "Invertebrate fauna module - light trapping (LepiLED) protocol Properties" ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-(lepiled)-protocol/collection.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/collection.ttl"^^xsd:anyURI ;
 .
 

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-cloud-cover.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-cloud-cover.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/9cf0b156-bd69-4419-afc3-3ee7aba23ca0>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-(lepiled)-protocol/weather-site-cloud-cover.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-cloud-cover.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b001aab8-d5c2-4268-a750-bed499386691> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/111a2971-f7c3-4d9d-b079-d9afa0bcc8b0> ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-cloud-cover.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-cloud-cover.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-cloud-cover.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b001aab8-d5c2-4268-a750-bed499386691> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/beacf237-e402-4911-a9e4-89925374df23> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/111a2971-f7c3-4d9d-b079-d9afa0bcc8b0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7d74d213-3fb8-46b4-9970-2544f555e279> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-precipitation.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-precipitation.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-precipitation.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/36e4cff5-f238-45e3-85ec-bdd0973f09d7> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/beacf237-e402-4911-a9e4-89925374df23> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b7e7f67b-d983-4167-baca-57cab6dd89a2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7d74d213-3fb8-46b4-9970-2544f555e279> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-precipitation.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-precipitation.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/cd8e079d-bf06-4853-9c19-3509a5c77fa4>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-(lepiled)-protocol/weather-site-precipitation.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-precipitation.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/36e4cff5-f238-45e3-85ec-bdd0973f09d7> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b7e7f67b-d983-4167-baca-57cab6dd89a2> ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-temperature.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-temperature.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/edef7d5c-2770-404c-b073-2349fb60312b>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-(lepiled)-protocol/weather-site-temperature.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-temperature.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/cd1530af-09a6-4666-98d5-580c0e65cf10> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a30248c3-33ce-4ffe-8130-7b03aa4e5322> ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-temperature.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-temperature.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-temperature.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/cd1530af-09a6-4666-98d5-580c0e65cf10> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/beacf237-e402-4911-a9e4-89925374df23> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a30248c3-33ce-4ffe-8130-7b03aa4e5322> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7d74d213-3fb8-46b4-9970-2544f555e279> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-wind.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-wind.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-wind.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0fb03c4e-ad42-445a-a2c5-688d7d7effd8> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/beacf237-e402-4911-a9e4-89925374df23> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e8f03cc8-33a3-4c2f-9a0d-95a40c34523d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7d74d213-3fb8-46b4-9970-2544f555e279> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-wind.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-wind.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/a717fe81-d27e-4ef6-b31b-f852494fb174>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-(lepiled)-protocol/weather-site-wind.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-light-trapping-lepiled-protocol/weather-site-wind.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0fb03c4e-ad42-445a-a2c5-688d7d7effd8> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e8f03cc8-33a3-4c2f-9a0d-95a40c34523d> ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/habitat-description.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/553e5dc9-db36-484c-b71c-75a9b76dcca5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ;
     urnp:valueType

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/weather-site-cloud-cover.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/weather-site-cloud-cover.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/weather-site-cloud-cover.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b001aab8-d5c2-4268-a750-bed499386691> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/553e5dc9-db36-484c-b71c-75a9b76dcca5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/111a2971-f7c3-4d9d-b079-d9afa0bcc8b0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/weather-site-precipitation.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/weather-site-precipitation.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/weather-site-precipitation.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/36e4cff5-f238-45e3-85ec-bdd0973f09d7> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/553e5dc9-db36-484c-b71c-75a9b76dcca5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b7e7f67b-d983-4167-baca-57cab6dd89a2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/weather-site-temperature.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/weather-site-temperature.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/weather-site-temperature.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/cd1530af-09a6-4666-98d5-580c0e65cf10> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/553e5dc9-db36-484c-b71c-75a9b76dcca5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a30248c3-33ce-4ffe-8130-7b03aa4e5322> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/weather-site-wind.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/weather-site-wind.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/weather-site-wind.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0fb03c4e-ad42-445a-a2c5-688d7d7effd8> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/553e5dc9-db36-484c-b71c-75a9b76dcca5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e8f03cc8-33a3-4c2f-9a0d-95a40c34523d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-pan-trapping-protocol/pan-trap-count-estimate.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-pan-trapping-protocol/pan-trap-count-estimate.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-pan-trapping-protocol/pan-trap-count-estimate.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8a68b4a9-167b-40f0-9222-293a2d20ffee> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/50054098-8127-4e09-b397-9e3c6d074570> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e4fa718e-76d1-47a2-87c9-b683a3ff3c18> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/666e5aa5-e545-4637-bc52-a296d647b303> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-pan-trapping-protocol/plant-species-in-flower.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-pan-trapping-protocol/plant-species-in-flower.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-pan-trapping-protocol/plant-species-in-flower.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/50054098-8127-4e09-b397-9e3c6d074570> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/2d95624b-e04e-4826-b97d-b74b90db4d56> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/666e5aa5-e545-4637-bc52-a296d647b303> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/invertebrate-group.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/invertebrate-group.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/invertebrate-group.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/5174e669-328b-4df8-879e-95b13738f475> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/656138c9-abc3-44c5-8d69-3522de407dee> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/31347751-82bd-4be8-bbae-ff0d80e319b5> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/79296cab-a02f-420d-b260-17c0e8691499> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/invertebrate-individual-life-stage-count.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/invertebrate-individual-life-stage-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/invertebrate-individual-life-stage-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8a68b4a9-167b-40f0-9222-293a2d20ffee> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/656138c9-abc3-44c5-8d69-3522de407dee> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ece0e09e-9e77-499c-b130-27d9c1d855bd> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/79296cab-a02f-420d-b260-17c0e8691499> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/invertebrate-life-stage-average-length.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/invertebrate-life-stage-average-length.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/invertebrate-life-stage-average-length.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/656138c9-abc3-44c5-8d69-3522de407dee> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/f2a11bc9-cc3c-4f8f-8ded-50ab46f73818> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/79296cab-a02f-420d-b260-17c0e8691499> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/invertebrate-life-stage.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/invertebrate-life-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/invertebrate-life-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/e8659ef7-fe60-4484-be17-0ed9c1495b97> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/656138c9-abc3-44c5-8d69-3522de407dee> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/1f3ac845-902a-435d-a404-4b6b3ed02764> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/79296cab-a02f-420d-b260-17c0e8691499> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/specimen-count.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/specimen-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-post-field-guideline-protocol/specimen-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8a68b4a9-167b-40f0-9222-293a2d20ffee> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/656138c9-abc3-44c5-8d69-3522de407dee> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/50da4103-111d-4876-800f-382d5033f1b4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/79296cab-a02f-420d-b260-17c0e8691499> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/bare-ground-percentage.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/bare-ground-percentage.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/bare-ground-percentage.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0fff4578-8fb7-4da1-a197-5078cafb1b25> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/9a3e5f88-72e1-43b0-8ba1-6cd63fdee2c5> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/dominant-species.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/dominant-species.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/dominant-species.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0fff4578-8fb7-4da1-a197-5078cafb1b25> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/8e782307-4e4d-4cdf-9b10-8d79794065a4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/estimated-percent-cover.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/estimated-percent-cover.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/estimated-percent-cover.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0fff4578-8fb7-4da1-a197-5078cafb1b25> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a9f6b098-96bf-4faf-a460-2d71213023f6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/litter-cover-percentage.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/litter-cover-percentage.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/litter-cover-percentage.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e6ed6e58-5916-4d31-9ed5-109ab3436fce> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0fff4578-8fb7-4da1-a197-5078cafb1b25> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e89eccd4-1deb-49cc-9103-272f6628a274> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/plant-phenology.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/plant-phenology.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/plant-phenology.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/110398ca-32fa-4f69-b7bb-5aa69d5a5004> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0fff4578-8fb7-4da1-a197-5078cafb1b25> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/33c1752f-b5f3-4ac9-9090-e9a4dd3096d1> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/substrate-cover-percentage.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/substrate-cover-percentage.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/substrate-cover-percentage.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0fff4578-8fb7-4da1-a197-5078cafb1b25> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/8993e97e-7639-4e71-bd89-9391321cb84f> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/substrate-type.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/substrate-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/substrate-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b061d7db-a608-4062-96d4-b367d6d9a792> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0fff4578-8fb7-4da1-a197-5078cafb1b25> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/75f55bf0-6972-42ba-ad46-7e24f91e8f6a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/weather-site-cloud-cover.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/weather-site-cloud-cover.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/weather-site-cloud-cover.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b001aab8-d5c2-4268-a750-bed499386691> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0fff4578-8fb7-4da1-a197-5078cafb1b25> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/111a2971-f7c3-4d9d-b079-d9afa0bcc8b0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/weather-site-precipitation.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/weather-site-precipitation.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/weather-site-precipitation.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/36e4cff5-f238-45e3-85ec-bdd0973f09d7> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0fff4578-8fb7-4da1-a197-5078cafb1b25> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b7e7f67b-d983-4167-baca-57cab6dd89a2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/weather-site-temperature.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/weather-site-temperature.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/weather-site-temperature.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/cd1530af-09a6-4666-98d5-580c0e65cf10> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0fff4578-8fb7-4da1-a197-5078cafb1b25> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a30248c3-33ce-4ffe-8130-7b03aa4e5322> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/weather-site-wind.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/weather-site-wind.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-module-wet-pitfall-protocol/weather-site-wind.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0fb03c4e-ad42-445a-a2c5-688d7d7effd8> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0fff4578-8fb7-4da1-a197-5078cafb1b25> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e8f03cc8-33a3-4c2f-9a0d-95a40c34523d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/age-class.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/age-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/age-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0e2641c3-0d7e-4d94-8cd7-02c21d564630> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/59df7c05-1521-4161-86e4-8e6a8feb4002> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/animal-pouch-condition.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/animal-pouch-condition.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/animal-pouch-condition.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/4fab0c1c-c127-474e-8f5e-4afe45fec0ed> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5ccfd7ed-12e4-42ed-83a1-1b85445f92d6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/animal-testes-condition.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/animal-testes-condition.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/animal-testes-condition.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c5d3877d-1a83-4a87-9bdd-05f77c516df6> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ff9c9d4e-5c91-42ea-9278-f7c9ed82569f> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/breeding-status.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/breeding-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/breeding-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b7dc10d2-c0aa-46b3-94da-685cd0a723e4> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/d8ed3241-8d97-4a63-be3a-5f610a4b8739> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/fauna-behaviour.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/fauna-behaviour.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/fauna-behaviour.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/1301857c-4e02-4000-966b-a0d0ce60368f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dfaf2438-6019-4632-85d8-0efc91930768> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/growth-form.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/growth-form.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/growth-form.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d0fc07a7-3ec9-45ed-8850-885a32828d3c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dd1769b9-c475-4732-915c-9b890a8d5f65> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/habitat-description.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/microhabitat-tier-1.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/microhabitat-tier-1.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/microhabitat-tier-1.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/66034d49-50d7-4042-a252-c2bd249d2a4b> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/71e15d2a-53d0-4c79-91a8-4746958703cb> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/microhabitat-tier-2.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/microhabitat-tier-2.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/microhabitat-tier-2.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/48f0bb5d-5451-42a1-ad60-7ddca485412d> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/664bd7cf-1cc4-4d19-8c33-8173471638c2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/number-of-individuals.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/number-of-individuals.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/number-of-individuals.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b2d28629-c986-4c05-9d4a-8b05e99a0a94> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/plant-phenology.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/plant-phenology.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/plant-phenology.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/110398ca-32fa-4f69-b7bb-5aa69d5a5004> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/33c1752f-b5f3-4ac9-9090-e9a4dd3096d1> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/sex.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/sex.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/sex.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/fcc3a1e1-3e35-4a4f-bd44-eface035025c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/40b39732-e10b-4c4e-968b-3404663a094d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/teat-status.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/teat-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/teat-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d2665d51-db1d-48ad-a80d-48593d280b76> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/2ad2e5ec-ec5c-4541-a98c-85278e93ad67> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/vaginal-condition.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/vaginal-condition.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/vaginal-condition.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/09de3b86-616e-49af-a34c-903cf7dec443> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/56059af9-44ff-4722-9cfc-6af2c69a5ed5> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/opportunistic-observations/vegetation-type.ttl
+++ b/vocab_files/observable_properties_by_module/opportunistic-observations/vegetation-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/opportunistic-observations/vegetation-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/2f585fb4-996c-483c-9f9f-65e5bbd171b3> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2be2d5ce-ca9d-4dff-8e79-948983944f95> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d3f85cc2-f3e8-4900-a2ac-19fc27fd14f9> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a9a73dfe-9165-4ad3-bccb-f1fa0a18e0be> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/aspect.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/aspect.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/aspect.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/plot-description/climatic-condition.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/climatic-condition.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/climatic-condition.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/2ebfee89-92db-44b3-bb89-06dd92798ae6> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dee23df7-4445-424f-b361-b2e0182be950> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/cover-class.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/cover-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/cover-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/6aaa330c-3d60-419b-a29b-a2dbc6d67928> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2be2d5ce-ca9d-4dff-8e79-948983944f95> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/f3e6e19b-ba79-4260-b493-8a2561033f9b> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/cover.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/cover.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/cover.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2be2d5ce-ca9d-4dff-8e79-948983944f95> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/60c714fa-4e8d-454d-b4cd-7fe77da7f47e> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/plot-description/disturbance-type.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/disturbance-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/disturbance-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/f5a470e8-d29f-4ff6-b50d-529b0444dbe4> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/632e4c3c-0e73-4b3d-b1d6-7b38897da5e8> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/dominant-species.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/dominant-species.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/dominant-species.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/32834f36-a478-45be-97f4-ff2ff51e9f5c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/8e782307-4e4d-4cdf-9b10-8d79794065a4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/plot-description/fire-history.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/fire-history.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/fire-history.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/d4fc54b1-0ad3-4512-86b7-d42b121ece45> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/growth-form.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/growth-form.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/growth-form.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d0fc07a7-3ec9-45ed-8850-885a32828d3c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dd1769b9-c475-4732-915c-9b890a8d5f65> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/growth-stage.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/growth-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/growth-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/096e018a-fb8f-4ba1-9fdc-302164e57682> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fcfda2f7-84f0-4c26-9f80-c051d129a094> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/height-class.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/height-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/height-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b1b05cd1-3b85-4639-a6af-799a34d88d43> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2be2d5ce-ca9d-4dff-8e79-948983944f95> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/242d081b-b3f4-4206-bc39-7aa42e9972ee> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/homogeneity-measure.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/homogeneity-measure.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/homogeneity-measure.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2be2d5ce-ca9d-4dff-8e79-948983944f95> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/plot-description/landform-element.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/landform-element.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/landform-element.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c1a58967-cb12-4c2c-a7ca-9cee2589919c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/9d4f8a2d-8e77-42dd-857b-0ecbc9c85696> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/landform-pattern.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/landform-pattern.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/landform-pattern.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/19d91a7a-2733-4b84-9d2b-4bda4808c003> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/58e4aba5-78c3-4361-b08a-ae39a93c8cb0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/outcrop-lithology.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/outcrop-lithology.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/outcrop-lithology.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/1d50eb79-685f-45ea-84b4-627154eddede> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8282fb22-4135-415c-8ca2-317860d102fb> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5af5cef1-179c-4bae-9037-42196668deff> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/second-dominant-species.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/second-dominant-species.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/second-dominant-species.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/32834f36-a478-45be-97f4-ff2ff51e9f5c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/909557e9-782f-45ea-8e89-8cf17a2c6ca6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/plot-description/slope-class.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/slope-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/slope-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d893e669-c530-4bc3-a057-a5799ffcb5db> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/132a1452-4fd7-473c-956b-3183dd315b67> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/slope.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/slope.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/slope.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/plot-description/structural-formation.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/structural-formation.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/structural-formation.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/6e9baf51-566e-4a5d-93c4-a6e097dc364d> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2be2d5ce-ca9d-4dff-8e79-948983944f95> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/103f26cb-0194-45d2-8b1a-e18e1da6df2b> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/surface-strew-lithology.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/surface-strew-lithology.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/surface-strew-lithology.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/1d50eb79-685f-45ea-84b4-627154eddede> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8282fb22-4135-415c-8ca2-317860d102fb> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6ee380ca-e9dc-4a9b-91c3-758b54e751eb> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/surface-strew-size.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/surface-strew-size.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/surface-strew-size.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/3b25ce0f-9eb7-4d2d-97ce-143858cfd4d4> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8282fb22-4135-415c-8ca2-317860d102fb> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/3eeef779-d4d9-4019-9543-be0abe54cc5c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/plot-description/third-dominant-species.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/third-dominant-species.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/third-dominant-species.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/32834f36-a478-45be-97f4-ff2ff51e9f5c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bfac1b1f-a14e-4e9a-ab7f-c43a8bc1a312> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fadc6db3-9474-45f5-a052-5b5002580c0a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/adequate-recruitment.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/adequate-recruitment.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/adequate-recruitment.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/36c493f1-6a2e-4d48-9c3a-df104d98124b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0f6d5b8e-4c3c-41b9-a8c0-99039718b59c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
     urnp:valueType tern:Boolean ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/diameter-at-breast-height-(dbh).ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/diameter-at-breast-height-(dbh).ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/diameter-at-breast-height-(dbh).ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/36c493f1-6a2e-4d48-9c3a-df104d98124b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6e1c8b97-3655-4a22-9647-02f2c756e789> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/36c493f1-6a2e-4d48-9c3a-df104d98124b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/growth-stage.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/growth-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/growth-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/096e018a-fb8f-4ba1-9fdc-302164e57682> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/36c493f1-6a2e-4d48-9c3a-df104d98124b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fcfda2f7-84f0-4c26-9f80-c051d129a094> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/life-stage.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/life-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/life-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/5f82c583-167b-4ed2-b25e-4d67decb3f2d> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/36c493f1-6a2e-4d48-9c3a-df104d98124b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ce3fd96d-e68d-4b14-b3fd-27690c566440> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/plant-height.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/plant-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/plant-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/36c493f1-6a2e-4d48-9c3a-df104d98124b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9da717-6c8e-4194-9385-c995d54702e4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/plant-status.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/plant-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/plant-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b7368a37-a4ac-4c84-8a78-1fb9755ad849> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/36c493f1-6a2e-4d48-9c3a-df104d98124b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ddd0c631-bfdd-4b0f-88de-a5eb1a0181c6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/sapling-count.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/sapling-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/sapling-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/36c493f1-6a2e-4d48-9c3a-df104d98124b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0f342ac9-800a-4298-a148-ffc953ecd393> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/seedling-count.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/seedling-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-age-class-protocol/seedling-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/36c493f1-6a2e-4d48-9c3a-df104d98124b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b6a5d847-0698-4cce-8a5e-f2719e142208> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/average-canopy-width.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/average-canopy-width.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/average-canopy-width.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/6bea1c41-0a98-465a-a146-1d3cfbf6f6fa> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5471254f-01e0-4201-8e15-888bb26b8fa5> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/diameter-at-breast-height-(dbh).ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/diameter-at-breast-height-(dbh).ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/diameter-at-breast-height-(dbh).ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/6bea1c41-0a98-465a-a146-1d3cfbf6f6fa> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6e1c8b97-3655-4a22-9647-02f2c756e789> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/6bea1c41-0a98-465a-a146-1d3cfbf6f6fa> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/life-stage.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/life-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/life-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/5f82c583-167b-4ed2-b25e-4d67decb3f2d> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/6bea1c41-0a98-465a-a146-1d3cfbf6f6fa> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ce3fd96d-e68d-4b14-b3fd-27690c566440> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/plant-height.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/plant-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/plant-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/6bea1c41-0a98-465a-a146-1d3cfbf6f6fa> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9da717-6c8e-4194-9385-c995d54702e4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/plant-status.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/plant-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/plant-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b7368a37-a4ac-4c84-8a78-1fb9755ad849> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/6bea1c41-0a98-465a-a146-1d3cfbf6f6fa> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ddd0c631-bfdd-4b0f-88de-a5eb1a0181c6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/vegetation-health.ttl
+++ b/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/vegetation-health.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/recruitment/recruitment-module-survivorship-protocol/vegetation-health.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/785f818c-0c8c-480b-b8e5-43ea9fda70f0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/6bea1c41-0a98-465a-a146-1d3cfbf6f6fa> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7d4eaa80-0f2a-4828-886e-34cd5a4e2746> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/aspect.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/aspect.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/aspect.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/coarse-fragments-abundance.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/coarse-fragments-abundance.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/coarse-fragments-abundance.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/bec608c4-3a66-4630-b666-cabb666ac8d2> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b3dd4df5-589b-476e-8e9e-0af6a7155759> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/component-of-microrelief.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/component-of-microrelief.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/component-of-microrelief.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/2bf9967f-c699-4193-9b4d-744e68efd1ad> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7f023c76-32e1-4c08-a52f-b900343b4b92> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/condition-of-soil-surface-when-dry.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/condition-of-soil-surface-when-dry.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/condition-of-soil-surface-when-dry.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/253cc4d0-b1f2-4a55-bdaf-e3c054703451> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/3a1ccb70-41dc-4f57-a74c-62e05aa02c61> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/disturbance-type.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/disturbance-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/disturbance-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/f5a470e8-d29f-4ff6-b50d-529b0444dbe4> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/632e4c3c-0e73-4b3d-b1d6-7b38897da5e8> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/erosion-type.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/erosion-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/erosion-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/4f3d9522-e612-40ef-ab8a-7d77960c9f8f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/9fc1503b-e690-41f0-a824-99f0e69699f1> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/gully-depth.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/gully-depth.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/gully-depth.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/7f0eb236-c8e8-4473-8f11-214487ba1d8a> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/4aa9e813-8c4c-4fa6-953b-32c59fdd97be> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/landform-element.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/landform-element.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/landform-element.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c1a58967-cb12-4c2c-a7ca-9cee2589919c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/9d4f8a2d-8e77-42dd-857b-0ecbc9c85696> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/landform-pattern.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/landform-pattern.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/landform-pattern.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/19d91a7a-2733-4b84-9d2b-4bda4808c003> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/58e4aba5-78c3-4361-b08a-ae39a93c8cb0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/landform-relief.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/landform-relief.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/landform-relief.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/9e377f67-190e-4d58-9ec9-adebedaf14e2> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/148f60c9-92c5-4324-81b6-61b59bccdb4c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/microrelief-biotic-agent.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/microrelief-biotic-agent.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/microrelief-biotic-agent.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/70b3ea97-90dd-49f7-9ca2-717a8deb6368> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e3dc0901-0bad-4157-bcb3-58aaffda313c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/microrelief-horizontal-interval-distance.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/microrelief-horizontal-interval-distance.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/microrelief-horizontal-interval-distance.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/22caefc0-0201-4bf2-a108-ef173d607bf4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/microrelief-vertical-interval-distance.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/microrelief-vertical-interval-distance.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/microrelief-vertical-interval-distance.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/2f87b7cc-c029-4784-92cf-c32055b5c9b7> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/modal-slope.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/modal-slope.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/modal-slope.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/443bf3da-0f2b-42ad-b9a5-b9608159556a> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/3f1ae206-0be8-4284-bce5-9f3a787a9baa> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/relative-inclination-of-slope-elements.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/relative-inclination-of-slope-elements.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/relative-inclination-of-slope-elements.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/844f1b7a-6a65-4994-9526-c337d84a7652> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8282fb22-4135-415c-8ca2-317860d102fb> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/30453b41-80b6-42d8-a388-893188414738> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/rock-outcrop-abundance.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/rock-outcrop-abundance.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/rock-outcrop-abundance.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c06f57b7-fde3-47c6-b410-8db0ec7e68e1> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fc03df84-7ac9-47c6-9b7b-1da3dcb36364> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/rock-outcrop-lithology.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/rock-outcrop-lithology.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/rock-outcrop-lithology.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/1d50eb79-685f-45ea-84b4-627154eddede> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5af5cef1-179c-4bae-9037-42196668deff> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/scald-erosion-degree.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/scald-erosion-degree.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/scald-erosion-degree.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/941e13e1-1bb3-471b-8502-9dc366c1dbf7> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/9c8486f2-d97e-40cf-aadb-66082452af54> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/shape-of-coarse-fragments.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/shape-of-coarse-fragments.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/shape-of-coarse-fragments.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/13c84b19-e2bb-48c4-93db-465bcad2dbb5> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/13c64e0f-4e24-4081-9744-2744599914c9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/size-of-coarse-fragments.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/size-of-coarse-fragments.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/size-of-coarse-fragments.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/06d01bf1-3863-44ea-95fe-4c62bb47b996> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5e84255c-6207-4bda-88c7-ed0d2a400519> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/slope-class.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/slope-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/slope-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d893e669-c530-4bc3-a057-a5799ffcb5db> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/132a1452-4fd7-473c-956b-3183dd315b67> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/slope-morphology-type.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/slope-morphology-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/slope-morphology-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/50e0e5aa-3abf-4883-a713-245701efe314> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b023d177-2c9b-4d58-86e6-099b742fcf1c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/slope-percent-tangent.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/slope-percent-tangent.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/slope-percent-tangent.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/bc537f95-6721-4a87-bd30-62d6377424ef> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/slope.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/slope.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/slope.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-coarse-fragment-alteration.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-coarse-fragment-alteration.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-coarse-fragment-alteration.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/87f4f5fc-d24d-4865-9b11-9ca9ac5e159f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e38d6585-30f4-4a50-bb3f-f9481ce9c595> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-coarse-fragment-strength.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-coarse-fragment-strength.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-coarse-fragment-strength.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/1ac1c1c1-5a64-47e4-b593-aabfefd57e46> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7739f6d5-06dd-42da-82ae-763fd62ff0f0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-drainage.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-drainage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-drainage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0c9132dc-48bf-4a9c-ac9b-0c8b1909afb4> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/c4ae89f9-49cb-4be8-b5f2-5f08177b8093> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-microrelief-gilgai.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-microrelief-gilgai.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-microrelief-gilgai.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/ca5e075d-fc73-4953-8564-18e9e15175cb> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/46dc0c67-027b-4a79-bbf5-d12d39fe01f0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-microrelief-hummocky.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-microrelief-hummocky.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-microrelief-hummocky.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/594ae399-a2bf-4177-9cd7-c74cec57b287> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/af8cc482-f896-4627-812a-9567af4662df> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-microrelief-proportion-of-gilgai-components.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-microrelief-proportion-of-gilgai-components.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-microrelief-proportion-of-gilgai-components.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c441cb41-6f65-417c-88b7-2c10375bf3f3> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e2c87884-5edf-4d87-a67d-6a13cf59e051> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-microrelief-type.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-microrelief-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-microrelief-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/457faa4f-74e8-4b8a-9e4b-541bb7c50441> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/3014409e-fa76-4159-8bd7-0a3bae695545> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-permeability.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-permeability.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-permeability.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/41a54b21-b885-4cfd-be09-7bedc4ae4dc4> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/3f431e7a-6f1c-4dcd-b452-1cb14226a56d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-runoff.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-runoff.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/soil-runoff.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/bcc7bb4d-a15a-4681-94e0-cb7a1117420a> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/054d2441-05fd-45d5-9480-ed7618005642> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/state-of-erosion.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/state-of-erosion.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/state-of-erosion.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/e7087186-7027-42c3-ab54-b65a39034dd1> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/3c5263b7-8104-46a9-af05-a0c33aadde07> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/surface-strew-lithology.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/surface-strew-lithology.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/surface-strew-lithology.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/1d50eb79-685f-45ea-84b4-627154eddede> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6ee380ca-e9dc-4a9b-91c3-758b54e751eb> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-gully-erosion-degree.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-gully-erosion-degree.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-gully-erosion-degree.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/42898383-1e9f-4d61-bd60-fca4669c1e05> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a43e0dc9-b886-41ba-84df-22225879b05f> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-mass-movement-erosion-degree.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-mass-movement-erosion-degree.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-mass-movement-erosion-degree.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c417aca7-46ef-42ae-90f0-6fb00ed9e357> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5af56582-cc92-4892-98f6-793047e7b5c2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-rill-erosion-degree.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-rill-erosion-degree.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-rill-erosion-degree.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c5bb4782-a8c7-4293-b6f0-b53c6c808f5f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5b9b43b7-6d79-4e92-bbbf-f9ec71a9e1d9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-sheet-erosion-degree.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-sheet-erosion-degree.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-sheet-erosion-degree.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/7d0706e7-4424-486b-a501-1958c660110b> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5f39a69f-c740-47e6-96d6-4ae18548830f> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-stream-bank-erosion-degree.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-stream-bank-erosion-degree.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-stream-bank-erosion-degree.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/f62945ca-2eeb-4055-a9cc-187185948d65> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6495fa13-99a9-4947-9ac7-913bb6e9e625> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-tunnel-erosion-degree.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-tunnel-erosion-degree.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/water-tunnel-erosion-degree.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b0e01539-05b6-4dc8-8a27-019c8fb5eeec> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/4528bf7c-5182-49a8-bedc-53c70f5e0dcd> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/wind-erosion-degree.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/wind-erosion-degree.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-plot-soil-description-protocol/wind-erosion-degree.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/5c1ef6e3-2da4-4fb2-be2c-3e92a93fe545> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5b7addb7-ae3d-47eb-b5d8-f34cc211875a> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/9dc64e42-c670-4682-8314-fcb35e3d74f4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-bulk-density-protocol/fine-earth-bulk-density.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-bulk-density-protocol/fine-earth-bulk-density.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-bulk-density-protocol/fine-earth-bulk-density.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/72b5340f-6654-4ee8-81dc-6a492964b20c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/460784be-8ad5-4c32-b171-93d69984c0b9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/d9e6739a-c2dd-4619-be43-1251449a6436> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-bulk-density-protocol/gross-soil-bulk-density.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-bulk-density-protocol/gross-soil-bulk-density.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-bulk-density-protocol/gross-soil-bulk-density.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/72b5340f-6654-4ee8-81dc-6a492964b20c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a344d029-4b47-455e-89d9-a1040877a5ce> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/d9e6739a-c2dd-4619-be43-1251449a6436> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-bulk-density-protocol/soil-bulk-density.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-bulk-density-protocol/soil-bulk-density.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-bulk-density-protocol/soil-bulk-density.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/72b5340f-6654-4ee8-81dc-6a492964b20c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ec510708-9ac1-4c8a-bfe2-31ba5bb693da> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/d9e6739a-c2dd-4619-be43-1251449a6436> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/coarse-fragments-abundance.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/coarse-fragments-abundance.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/coarse-fragments-abundance.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/bec608c4-3a66-4630-b666-cabb666ac8d2> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b3dd4df5-589b-476e-8e9e-0af6a7155759> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/coarse-fragments-lithology.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/coarse-fragments-lithology.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/coarse-fragments-lithology.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/1d50eb79-685f-45ea-84b4-627154eddede> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/4062f093-424b-441e-86fc-648d820ae1fb> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/coarse-fragments-shape.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/coarse-fragments-shape.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/coarse-fragments-shape.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/13c84b19-e2bb-48c4-93db-465bcad2dbb5> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/d83560e6-0356-446e-a8b5-e64b82e3c362> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/coarse-fragments-size.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/coarse-fragments-size.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/coarse-fragments-size.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/06d01bf1-3863-44ea-95fe-4c62bb47b996> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/92ae6036-50a8-446c-8df8-573860011b79> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/horizon-boundary-distinctness.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/horizon-boundary-distinctness.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/horizon-boundary-distinctness.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/1c6b54da-bb31-4496-974e-050531b15e30> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/181f2d40-8cb7-4b0e-83cb-90ca77b6327f> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/horizon-boundry-shape.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/horizon-boundry-shape.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/horizon-boundry-shape.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/2f514fb5-6c23-4fff-beed-858722a0f586> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ee03aeec-28ef-4910-94af-338a981bb40d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/mean-macropore-diameter.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/mean-macropore-diameter.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/mean-macropore-diameter.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/3c3ccc22-949a-4892-9c51-7b458a823fcd> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/796022f7-ccba-419a-8f70-020ee9e8e3f8> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-compound-pedality.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-compound-pedality.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-compound-pedality.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/75de6044-7575-472a-9a72-2c9006a8c9b1> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/180f3ff5-a3ea-4b85-a947-f5a14156e833> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-consistency-strength-of-soil.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-consistency-strength-of-soil.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-consistency-strength-of-soil.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/9f599dbb-458f-4d8a-846a-fd1a080f8853> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6b2ba4eb-89d1-46bd-a845-f0b32d129806> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-consistency-water-status.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-consistency-water-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-consistency-water-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/e1573937-3a4e-4df6-beba-29e25e7c5596> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/74281a72-db08-4928-83a9-956187e06528> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-cutan-abunance.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-cutan-abunance.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-cutan-abunance.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/984fbd63-e521-4fef-80f9-bcb9307a76a9> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/90dc7158-cc88-45ba-ad74-be80321e0344> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-cutan-distinctness.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-cutan-distinctness.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-cutan-distinctness.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/e9ea1cd7-4e33-4086-b0ce-cd2f00c2b8ad> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7cd4d597-be78-4c0e-b2b2-7a1206870974> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-cutan-type.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-cutan-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-cutan-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/e2e7323b-774a-4be0-a40d-2d52e042dd17> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/786d4846-5b75-4b11-aba0-71fa40fd180a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-dispersion-score.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-dispersion-score.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-dispersion-score.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0e0a3e73-4b7a-4ffb-8b91-ee0748688bb1> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/1a8ca840-af43-41f2-bc69-965894bccd1a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-effervescence.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-effervescence.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-effervescence.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/4f3a874f-4629-498a-b270-6880ca43b3a6> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/bfe1e9d6-4040-45c1-a2a9-bcb634b745ac> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-electrical-conductivity.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-electrical-conductivity.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-electrical-conductivity.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/22815fee-434e-4e21-b85f-8005a669a865> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-fabric-details.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-fabric-details.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-fabric-details.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/2d1d8394-6641-4d74-988a-8ec66425ffdd> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/4a2a4fda-e1b8-436b-bd10-b3616de53ea9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon-depth-lower.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon-depth-lower.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon-depth-lower.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/66f227c3-6267-4068-9493-dfd909592aaf> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon-depth-upper.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon-depth-upper.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon-depth-upper.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/3b693f41-50b2-4469-bdbb-3b5b877fa2a9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon-depth.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon-depth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon-depth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/c0b5ae33-438d-42ca-b78e-e384d139fe27> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon-suffix.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon-suffix.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon-suffix.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/31d3921f-1fcb-4ec2-99a6-749c7b9e4798> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/224075e9-0998-4cac-95c4-babe5b63e3bf> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-horizon.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/bcd57c16-0e94-48c9-aee7-296a0e13b3ca> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7761c9df-0ce5-4de6-9c92-f1a8965b9481> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-matrix-dry-color.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-matrix-dry-color.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-matrix-dry-color.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/2a5c4ab0-124b-4430-a612-e069173bc82a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-matrix-wet-color.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-matrix-wet-color.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-matrix-wet-color.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/bdc0806b-acdd-402d-a1c1-6b9618f98401> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-moisture-status.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-moisture-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-moisture-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/a1e434a8-3fbb-4323-a0ae-0e31308eba8b> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/759b8562-b416-4fdc-924e-b55288018286> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-abundance.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-abundance.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-abundance.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/100f6f80-d438-465a-8f57-5a76a038b961> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/049cd754-cdc4-46e3-868f-fefa258522c9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-boundary-distinctness.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-boundary-distinctness.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-boundary-distinctness.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/51622960-af4e-4398-82ca-a17223de1431> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/8861378e-8012-4ce4-932b-ed9b3d25de61> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-color.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-color.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-color.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/a6d2b7d3-fe4f-4bf6-82ce-d53ae951cb7d> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a0b98f1c-ebcb-4a06-b5bc-919de1e02331> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-contrast.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-contrast.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-contrast.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/a0f8cc94-abbd-482b-8947-6017bc5f55e5> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/922aa129-61d2-499e-9f2b-d57f3617737c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-size.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-size.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-size.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c8dd7af4-8e57-4f59-848a-66712349754a> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dd220b97-75b8-4d73-af57-793e431459b6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-type.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-mottle-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b12461fc-166e-477b-a58c-60682848010e> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/79df1f41-1a8e-44af-8362-87ac7944cfc3> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pan-cementation.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pan-cementation.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pan-cementation.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/ad3e7729-fbe4-4b93-8428-74f6ced865c1> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/50baa5cb-43e1-465f-a842-0cf598576eb9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pan-continuity.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pan-continuity.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pan-continuity.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c80e269f-a328-4214-b690-849259e67e75> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/1c64a9a4-aee6-492a-a7cd-a375c2d1da27> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pan-structure.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pan-structure.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pan-structure.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/295ca7cc-f6e6-451d-a0de-667fa3187378> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/151ce1f3-9ff5-456c-b780-806f705d97c6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pan-type.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pan-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pan-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/995adb71-6439-4cd3-9ece-bb87a8a217c0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/084ba6fb-0cfd-48a1-bf00-e91c9bc0cea0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-ph.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-ph.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-ph.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/f8993f1e-b4d8-47b8-acdd-a74dd84e845e> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pit-depth.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pit-depth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-pit-depth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/cc960a7d-33a1-446a-85dc-8d1f8fda9996> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-sample-depth-lower.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-sample-depth-lower.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-sample-depth-lower.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5040cfbe-eb65-4ce8-899c-f13ab841e7c3> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-sample-depth-upper.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-sample-depth-upper.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-sample-depth-upper.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/2729becc-9e41-4303-9311-ec2a506e62e5> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-sample-depth.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-sample-depth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-sample-depth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/93932e83-41aa-48e6-b05c-ecde9bfcca99> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-abundance.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-abundance.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-abundance.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/9b4820fb-6ee1-439c-8972-f642b9a7b5f8> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b23d0935-6d2c-4657-a416-1e9f61761bad> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-form.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-form.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-form.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/e2a473c3-a2e3-44fc-a309-a662c6e53542> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/898c9bd8-ae04-4917-94b9-75725c050850> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-magnetic-attributes.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-magnetic-attributes.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-magnetic-attributes.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/f503ff93-f7d7-4419-9d1e-6807e96dc2c1> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/764d2097-c55e-46c4-a64b-2bc2204c22af> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-nature.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-nature.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-nature.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/2e870427-8563-4d61-b7ac-3556aaf0cbf2> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/2884455e-8016-44e9-8b18-5f219c89bd26> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-size.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-size.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-segregation-size.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/f795d7e8-1bc9-4efa-98b7-e19717c66282> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/958da592-ff9b-4110-92f1-c82fe0472de1> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-slaking-score.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-slaking-score.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-slaking-score.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c2408628-477b-4867-bc12-532126801973> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/040526b4-50a2-4bcf-a16a-ed5d1b5f7c4c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-structure-grade.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-structure-grade.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-structure-grade.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0cfcb0fc-75e3-4de1-a2d3-78c357a3ce06> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/8e87bc47-7bc6-4ad7-81ac-17d4968004e8> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-structure-size.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-structure-size.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-structure-size.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/f5226b34-eac7-42c3-9730-b7fdb2479697> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dd8dcc19-8a0c-4d9f-995f-a449408b5aa5> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-structure-type.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-structure-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-structure-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/ba792941-7941-43c8-b992-b7f54dddf14c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5b4dc0ad-3b4d-47d2-a775-7b405b4ff570> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-texture-grade.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-texture-grade.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-texture-grade.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/ecdcb81a-cbe9-4113-b9e9-422a0e6c751f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/062078e4-716e-4f27-a0f2-5e9715ddb6dc> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-texture-modifier.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-texture-modifier.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-texture-modifier.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/65d26894-1b2e-4c80-92ee-fa420142ed67> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/51101df7-f8ac-4b5f-8890-482cc7a083ed> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-texture-qualification.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-texture-qualification.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-texture-qualification.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/367b9d17-0e08-4ad4-9c44-20e8c3f515fb> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/c0e91cf7-b099-498a-8450-a37783404b3c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-voids-coarse-macropore-abundance.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-voids-coarse-macropore-abundance.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-voids-coarse-macropore-abundance.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/ee3a4058-d8de-43b8-a002-3f072f039b75> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/c0512e0a-98dd-4f38-8db9-db79769457bf> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-voids-cracks.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-voids-cracks.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-voids-cracks.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/1acac98b-808d-4efa-aa27-a0cb7782e63f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/f6504250-db2c-47ae-98f5-17f9534aff84> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-voids-fine-macropore-abundance.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-voids-fine-macropore-abundance.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-pit-characterization-protocol/soil-voids-fine-macropore-abundance.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/5c685afb-1a56-4261-93f1-8440fbc65ef3> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/06461021-a6c2-4175-9651-23653c2b9116> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/760751fb-7a1b-4874-9de6-98127febac58> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0408a67f-2448-4151-bc1e-d97b6ff34e4f> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/horizon-boundary-distinctness.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/horizon-boundary-distinctness.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/horizon-boundary-distinctness.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/1c6b54da-bb31-4496-974e-050531b15e30> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/eaf5a55e-e053-4818-a808-4722b1da4d17> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/181f2d40-8cb7-4b0e-83cb-90ca77b6327f> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/horizon-boundry-shape.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/horizon-boundry-shape.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/horizon-boundry-shape.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/2f514fb5-6c23-4fff-beed-858722a0f586> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/eaf5a55e-e053-4818-a808-4722b1da4d17> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ee03aeec-28ef-4910-94af-338a981bb40d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-horizon-depth-lower.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-horizon-depth-lower.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-horizon-depth-lower.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/eaf5a55e-e053-4818-a808-4722b1da4d17> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/66f227c3-6267-4068-9493-dfd909592aaf> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-horizon-depth-upper.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-horizon-depth-upper.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-horizon-depth-upper.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/eaf5a55e-e053-4818-a808-4722b1da4d17> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/3b693f41-50b2-4469-bdbb-3b5b877fa2a9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-horizon-depth.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-horizon-depth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-horizon-depth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/eaf5a55e-e053-4818-a808-4722b1da4d17> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/c0b5ae33-438d-42ca-b78e-e384d139fe27> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-horizon.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-horizon.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-horizon.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/bcd57c16-0e94-48c9-aee7-296a0e13b3ca> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/eaf5a55e-e053-4818-a808-4722b1da4d17> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7761c9df-0ce5-4de6-9c92-f1a8965b9481> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-sample-depth-lower.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-sample-depth-lower.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-sample-depth-lower.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/eaf5a55e-e053-4818-a808-4722b1da4d17> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/5040cfbe-eb65-4ce8-899c-f13ab841e7c3> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-sample-depth-upper.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-sample-depth-upper.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-sample-depth-upper.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/eaf5a55e-e053-4818-a808-4722b1da4d17> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/2729becc-9e41-4303-9311-ec2a506e62e5> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-sample-depth.ttl
+++ b/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-sample-depth.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/soil/soil-module-soil-subsite-sampling-protocol/soil-sample-depth.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/eaf5a55e-e053-4818-a808-4722b1da4d17> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/93932e83-41aa-48e6-b05c-ecde9bfcca99> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/condition-thresholds.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/condition-thresholds.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/condition-thresholds.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2e7e218c-c307-4dfa-9560-90d8f03e401e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/92d0eaf3-0352-45ba-b173-f82923cdd795> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4da8c123-b886-4881-91b3-1ff6a9b30e3c> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/disturbance-type.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/disturbance-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/disturbance-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/f5a470e8-d29f-4ff6-b50d-529b0444dbe4> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2e7e218c-c307-4dfa-9560-90d8f03e401e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/632e4c3c-0e73-4b3d-b1d6-7b38897da5e8> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4da8c123-b886-4881-91b3-1ff6a9b30e3c> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/species-and-cover.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/species-and-cover.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/species-and-cover.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2e7e218c-c307-4dfa-9560-90d8f03e401e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e706382f-3cf5-48ff-bc86-6e8902dc2aaf> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4da8c123-b886-4881-91b3-1ff6a9b30e3c> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/target-community.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/target-community.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/target-community.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0e718c57-74b4-441c-bf2d-3bfeff78b131> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2e7e218c-c307-4dfa-9560-90d8f03e401e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/401f1d32-68c0-49da-9755-dfb5d1ede660> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4da8c123-b886-4881-91b3-1ff6a9b30e3c> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/vegetation-health.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/vegetation-health.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/vegetation-health.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/785f818c-0c8c-480b-b8e5-43ea9fda70f0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2e7e218c-c307-4dfa-9560-90d8f03e401e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7d4eaa80-0f2a-4828-886e-34cd5a4e2746> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4da8c123-b886-4881-91b3-1ff6a9b30e3c> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/weeds.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/weeds.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-ecological-community-protocol/weeds.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2e7e218c-c307-4dfa-9560-90d8f03e401e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/cefdf9e3-63cb-42fb-9d9b-790dbdebbe45> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4da8c123-b886-4881-91b3-1ff6a9b30e3c> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-active/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-active/habitat-description.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-active/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5a31ad93-8729-435d-b3ba-e361ab70a10c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4bfc4796-a02f-461f-b17d-383aad328e61> ;
     urnp:valueType

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-active/number-of-individuals.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-active/number-of-individuals.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-active/number-of-individuals.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8a68b4a9-167b-40f0-9222-293a2d20ffee> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5a31ad93-8729-435d-b3ba-e361ab70a10c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b2d28629-c986-4c05-9d4a-8b05e99a0a94> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4bfc4796-a02f-461f-b17d-383aad328e61> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-passive/age-class.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-passive/age-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-passive/age-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0e2641c3-0d7e-4d94-8cd7-02c21d564630> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5ed1bd2f-f3f3-4b62-a485-c07ccb454e66> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/59df7c05-1521-4161-86e4-8e6a8feb4002> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4741800d-1b44-4805-a849-4436c80ff911> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-passive/fauna-length.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-passive/fauna-length.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-passive/fauna-length.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5ed1bd2f-f3f3-4b62-a485-c07ccb454e66> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7905c3ec-3901-4fb9-a042-b83066bee975> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4741800d-1b44-4805-a849-4436c80ff911> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-passive/fauna-weight.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-passive/fauna-weight.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-passive/fauna-weight.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5ed1bd2f-f3f3-4b62-a485-c07ccb454e66> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/375a2c90-71d6-4ff4-99e4-bc033f2bb03c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4741800d-1b44-4805-a849-4436c80ff911> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-passive/sex.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-passive/sex.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-passive/sex.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/fcc3a1e1-3e35-4a4f-bd44-eface035025c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5ed1bd2f-f3f3-4b62-a485-c07ccb454e66> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/40b39732-e10b-4c4e-968b-3404663a094d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4741800d-1b44-4805-a849-4436c80ff911> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/diameter-at-breast-height-(dbh).ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/diameter-at-breast-height-(dbh).ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/diameter-at-breast-height-(dbh).ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9b5e04d5-182c-4644-8bba-4c8f6399b527> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6e1c8b97-3655-4a22-9647-02f2c756e789> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/growth-form.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/growth-form.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/growth-form.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d0fc07a7-3ec9-45ed-8850-885a32828d3c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9b5e04d5-182c-4644-8bba-4c8f6399b527> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dd1769b9-c475-4732-915c-9b890a8d5f65> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/growth-stage.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/growth-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/growth-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/096e018a-fb8f-4ba1-9fdc-302164e57682> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9b5e04d5-182c-4644-8bba-4c8f6399b527> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fcfda2f7-84f0-4c26-9f80-c051d129a094> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/habitat-description.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9b5e04d5-182c-4644-8bba-4c8f6399b527> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ;
     urnp:valueType

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/life-stage.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/life-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/life-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/5f82c583-167b-4ed2-b25e-4d67decb3f2d> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9b5e04d5-182c-4644-8bba-4c8f6399b527> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ce3fd96d-e68d-4b14-b3fd-27690c566440> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/number-of-individuals.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/number-of-individuals.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/number-of-individuals.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9b5e04d5-182c-4644-8bba-4c8f6399b527> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b2d28629-c986-4c05-9d4a-8b05e99a0a94> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/plant-height.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/plant-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/plant-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9b5e04d5-182c-4644-8bba-4c8f6399b527> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9da717-6c8e-4194-9385-c995d54702e4> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/plant-size-width.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/plant-size-width.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/plant-size-width.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9b5e04d5-182c-4644-8bba-4c8f6399b527> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/9a73de99-19c7-438e-829d-c363ac86b570> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/vegetation-health.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/vegetation-health.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/vegetation-health.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/785f818c-0c8c-480b-b8e5-43ea9fda70f0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9b5e04d5-182c-4644-8bba-4c8f6399b527> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7d4eaa80-0f2a-4828-886e-34cd5a4e2746> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/growth-form.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/growth-form.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/growth-form.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d0fc07a7-3ec9-45ed-8850-885a32828d3c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7a3a06af-8c03-414f-9040-fd4bbf691384> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dd1769b9-c475-4732-915c-9b890a8d5f65> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/growth-stage.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/growth-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/growth-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/096e018a-fb8f-4ba1-9fdc-302164e57682> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7a3a06af-8c03-414f-9040-fd4bbf691384> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fcfda2f7-84f0-4c26-9f80-c051d129a094> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/habitat-description.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7a3a06af-8c03-414f-9040-fd4bbf691384> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ;
     urnp:valueType

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/life-stage.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/life-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/life-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/5f82c583-167b-4ed2-b25e-4d67decb3f2d> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7a3a06af-8c03-414f-9040-fd4bbf691384> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/ce3fd96d-e68d-4b14-b3fd-27690c566440> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/number-of-individuals.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/number-of-individuals.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/number-of-individuals.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7a3a06af-8c03-414f-9040-fd4bbf691384> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b2d28629-c986-4c05-9d4a-8b05e99a0a94> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/vegetation-health.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/vegetation-health.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/vegetation-health.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/785f818c-0c8c-480b-b8e5-43ea9fda70f0> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7a3a06af-8c03-414f-9040-fd4bbf691384> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/7d4eaa80-0f2a-4828-886e-34cd5a4e2746> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-duration-of-precipitation.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-duration-of-precipitation.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-duration-of-precipitation.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/34789810-a3bc-4def-9ddb-d14ff4ba02ea> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/ccaedec9-ffdc-42df-9c9f-7dce8b14fb91> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/25d4c7b7-4cdf-4b69-8774-064055c74e23> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/33544e85-741a-4646-ba32-c820486f0a33> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-site-cloud-cover.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-site-cloud-cover.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-site-cloud-cover.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b001aab8-d5c2-4268-a750-bed499386691> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/ccaedec9-ffdc-42df-9c9f-7dce8b14fb91> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/111a2971-f7c3-4d9d-b079-d9afa0bcc8b0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/33544e85-741a-4646-ba32-c820486f0a33> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-site-precipitation.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-site-precipitation.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-site-precipitation.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/36e4cff5-f238-45e3-85ec-bdd0973f09d7> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/ccaedec9-ffdc-42df-9c9f-7dce8b14fb91> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b7e7f67b-d983-4167-baca-57cab6dd89a2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/33544e85-741a-4646-ba32-c820486f0a33> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-site-temperature.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-site-temperature.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-site-temperature.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/cd1530af-09a6-4666-98d5-580c0e65cf10> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/ccaedec9-ffdc-42df-9c9f-7dce8b14fb91> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a30248c3-33ce-4ffe-8130-7b03aa4e5322> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/33544e85-741a-4646-ba32-c820486f0a33> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-site-wind.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-site-wind.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-general-field-protocol/weather-site-wind.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0fb03c4e-ad42-445a-a2c5-688d7d7effd8> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/ccaedec9-ffdc-42df-9c9f-7dce8b14fb91> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e8f03cc8-33a3-4c2f-9a0d-95a40c34523d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/33544e85-741a-4646-ba32-c820486f0a33> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vegetation-mapping/disturbance-type.ttl
+++ b/vocab_files/observable_properties_by_module/vegetation-mapping/disturbance-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vegetation-mapping/disturbance-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/f5a470e8-d29f-4ff6-b50d-529b0444dbe4> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2089561b-5b49-472a-812f-3de661505ccb> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/632e4c3c-0e73-4b3d-b1d6-7b38897da5e8> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/15361f98-7669-410e-9b04-e9be069c7508> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vegetation-mapping/dominant-growth-form.ttl
+++ b/vocab_files/observable_properties_by_module/vegetation-mapping/dominant-growth-form.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vegetation-mapping/dominant-growth-form.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/6e9baf51-566e-4a5d-93c4-a6e097dc364d> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2089561b-5b49-472a-812f-3de661505ccb> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/4a550407-5158-497c-982a-9f1b662b73e9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/15361f98-7669-410e-9b04-e9be069c7508> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vegetation-mapping/fire-history.ttl
+++ b/vocab_files/observable_properties_by_module/vegetation-mapping/fire-history.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vegetation-mapping/fire-history.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/d4fc54b1-0ad3-4512-86b7-d42b121ece45> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2089561b-5b49-472a-812f-3de661505ccb> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/cf1aef8a-a782-4480-9c41-a7f6d170d7fc> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/15361f98-7669-410e-9b04-e9be069c7508> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vegetation-mapping/foliage-projective-cover.ttl
+++ b/vocab_files/observable_properties_by_module/vegetation-mapping/foliage-projective-cover.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vegetation-mapping/foliage-projective-cover.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2be2d5ce-ca9d-4dff-8e79-948983944f95> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2089561b-5b49-472a-812f-3de661505ccb> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0378976a-0018-4604-826d-1886ca5f38c3> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/15361f98-7669-410e-9b04-e9be069c7508> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/vegetation-mapping/growth-stage.ttl
+++ b/vocab_files/observable_properties_by_module/vegetation-mapping/growth-stage.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vegetation-mapping/growth-stage.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/096e018a-fb8f-4ba1-9fdc-302164e57682> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2089561b-5b49-472a-812f-3de661505ccb> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fcfda2f7-84f0-4c26-9f80-c051d129a094> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/15361f98-7669-410e-9b04-e9be069c7508> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vegetation-mapping/homogeneity-measure.ttl
+++ b/vocab_files/observable_properties_by_module/vegetation-mapping/homogeneity-measure.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vegetation-mapping/homogeneity-measure.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2be2d5ce-ca9d-4dff-8e79-948983944f95> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2089561b-5b49-472a-812f-3de661505ccb> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/15361f98-7669-410e-9b04-e9be069c7508> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/vegetation-mapping/maximum-height.ttl
+++ b/vocab_files/observable_properties_by_module/vegetation-mapping/maximum-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vegetation-mapping/maximum-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2be2d5ce-ca9d-4dff-8e79-948983944f95> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2089561b-5b49-472a-812f-3de661505ccb> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/da5bd3cd-e52c-4cfe-9ab6-ac9474eb94ff> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/15361f98-7669-410e-9b04-e9be069c7508> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/vegetation-mapping/physical-substrate-cover.ttl
+++ b/vocab_files/observable_properties_by_module/vegetation-mapping/physical-substrate-cover.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vegetation-mapping/physical-substrate-cover.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2089561b-5b49-472a-812f-3de661505ccb> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/cbea81bc-2447-4c78-bab8-54d6637e2178> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/15361f98-7669-410e-9b04-e9be069c7508> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/age-class.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/age-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/age-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0e2641c3-0d7e-4d94-8cd7-02c21d564630> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/662320e4-4633-4aa3-9c78-4776d22e632e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/59df7c05-1521-4161-86e4-8e6a8feb4002> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/fauna-behaviour.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/fauna-behaviour.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/fauna-behaviour.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/1301857c-4e02-4000-966b-a0d0ce60368f> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/662320e4-4633-4aa3-9c78-4776d22e632e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dfaf2438-6019-4632-85d8-0efc91930768> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/662320e4-4633-4aa3-9c78-4776d22e632e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/number-of-individuals.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/number-of-individuals.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/number-of-individuals.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8a68b4a9-167b-40f0-9222-293a2d20ffee> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/662320e4-4633-4aa3-9c78-4776d22e632e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b2d28629-c986-4c05-9d4a-8b05e99a0a94> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/reproductive-status.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/reproductive-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/reproductive-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b7dc10d2-c0aa-46b3-94da-685cd0a723e4> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/662320e4-4633-4aa3-9c78-4776d22e632e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e8659dca-7861-407f-b405-55576ddcc276> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/sex.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/sex.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/sex.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/fcc3a1e1-3e35-4a4f-bd44-eface035025c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/662320e4-4633-4aa3-9c78-4776d22e632e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/40b39732-e10b-4c4e-968b-3404663a094d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/weather-site-cloud-cover.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/weather-site-cloud-cover.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/weather-site-cloud-cover.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b001aab8-d5c2-4268-a750-bed499386691> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/662320e4-4633-4aa3-9c78-4776d22e632e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/111a2971-f7c3-4d9d-b079-d9afa0bcc8b0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/weather-site-precipitation.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/weather-site-precipitation.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/weather-site-precipitation.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/36e4cff5-f238-45e3-85ec-bdd0973f09d7> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/662320e4-4633-4aa3-9c78-4776d22e632e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b7e7f67b-d983-4167-baca-57cab6dd89a2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/weather-site-temperature.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/weather-site-temperature.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/weather-site-temperature.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/cd1530af-09a6-4666-98d5-580c0e65cf10> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/662320e4-4633-4aa3-9c78-4776d22e632e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a30248c3-33ce-4ffe-8130-7b03aa4e5322> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/weather-site-wind.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/weather-site-wind.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-active-and-passive-searching-protocol/weather-site-wind.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0fb03c4e-ad42-445a-a2c5-688d7d7effd8> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/662320e4-4633-4aa3-9c78-4776d22e632e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e8f03cc8-33a3-4c2f-9a0d-95a40c34523d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/bird-activity-type.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/bird-activity-type.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/bird-activity-type.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c7a51f30-97e8-4232-b1f3-a248d58f1a60> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d2768d6b-769c-4355-9358-6d2d98de4baf> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/045fa754-487a-4346-8128-403c646a903b> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/bird-breeding-activity.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/bird-breeding-activity.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/bird-breeding-activity.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/028f570d-0cf0-4e94-b288-ac8d852f2230> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d2768d6b-769c-4355-9358-6d2d98de4baf> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/72cca5e4-2dc6-4a96-92e3-6f1e844b243c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d2768d6b-769c-4355-9358-6d2d98de4baf> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/maturity.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/maturity.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/maturity.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/a01656de-9627-4067-ad09-269242badbcb> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d2768d6b-769c-4355-9358-6d2d98de4baf> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0bc0fae9-6243-4d9f-a547-ef4c36244b5d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/number-of-individuals.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/number-of-individuals.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/number-of-individuals.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8a68b4a9-167b-40f0-9222-293a2d20ffee> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d2768d6b-769c-4355-9358-6d2d98de4baf> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b2d28629-c986-4c05-9d4a-8b05e99a0a94> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/sex.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/sex.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/sex.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/fcc3a1e1-3e35-4a4f-bd44-eface035025c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d2768d6b-769c-4355-9358-6d2d98de4baf> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/40b39732-e10b-4c4e-968b-3404663a094d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/weather-site-cloud-cover.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/weather-site-cloud-cover.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/weather-site-cloud-cover.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/b001aab8-d5c2-4268-a750-bed499386691> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d2768d6b-769c-4355-9358-6d2d98de4baf> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/111a2971-f7c3-4d9d-b079-d9afa0bcc8b0> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/weather-site-precipitation.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/weather-site-precipitation.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/weather-site-precipitation.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/36e4cff5-f238-45e3-85ec-bdd0973f09d7> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d2768d6b-769c-4355-9358-6d2d98de4baf> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b7e7f67b-d983-4167-baca-57cab6dd89a2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/weather-site-temperature.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/weather-site-temperature.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/weather-site-temperature.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/cd1530af-09a6-4666-98d5-580c0e65cf10> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d2768d6b-769c-4355-9358-6d2d98de4baf> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a30248c3-33ce-4ffe-8130-7b03aa4e5322> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/weather-site-wind.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/weather-site-wind.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-bird-survey/weather-site-wind.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0fb03c4e-ad42-445a-a2c5-688d7d7effd8> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/d2768d6b-769c-4355-9358-6d2d98de4baf> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/e8f03cc8-33a3-4c2f-9a0d-95a40c34523d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/age-class.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/age-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/age-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0e2641c3-0d7e-4d94-8cd7-02c21d564630> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/59df7c05-1521-4161-86e4-8e6a8feb4002> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/age-class.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/age-class.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/ed5cec4c-3c17-4179-b19b-be54e5d6dd61>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/age-class.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/age-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/0e2641c3-0d7e-4d94-8cd7-02c21d564630> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/59df7c05-1521-4161-86e4-8e6a8feb4002> ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/animal-weight.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/animal-weight.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/animal-weight.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/d78e0ad6-9ac8-4adc-a796-61ad458726b3> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/animal-weight.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/animal-weight.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/d6f78892-972c-4cbc-8564-19ddbeece76b>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/animal-weight.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/animal-weight.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/d78e0ad6-9ac8-4adc-a796-61ad458726b3> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/body-condition.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/body-condition.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/549bb6fb-1247-4f37-9aa4-afef1568301b>
+<https://linked.data.gov.au/def/nrm/11d11ce4-376d-4e32-8ce9-e051cb56c4e7>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/vertebrate-class.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/body-condition.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/8997be1e-cf91-4ca6-a641-eb57aa10d9e6> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/a0bf61f1-56fa-4653-8f68-be2f732357c8> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Text ;
 .

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/body-condition.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/body-condition.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/body-condition.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/a0bf61f1-56fa-4653-8f68-be2f732357c8> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/body-length.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/body-length.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/e6580067-eba7-4c4f-83ba-7d8e86dbb04b>
+<https://linked.data.gov.au/def/nrm/eca183a6-7c7d-4380-a1b0-2bc50e923d8f>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/tail-length.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/body-length.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/38d1419f-7f3b-4d0e-a2f6-4b152e2d91f7> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9b8207-3282-4b42-b68c-c33951539016> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;
 .

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/body-length.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/body-length.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/body-length.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9b8207-3282-4b42-b68c-c33951539016> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/collection.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/collection.ttl
@@ -27,6 +27,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         <https://linked.data.gov.au/def/nrm/d78e0ad6-9ac8-4adc-a796-61ad458726b3> ,
         <https://linked.data.gov.au/def/nrm/fe18c3aa-7af1-4fe8-bf5f-dcec29a3bea9> ;
     skos:prefLabel "Vertebrate fauna module - identify, measure and release protocol Properties" ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/collection.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/collection.ttl"^^xsd:anyURI ;
 .
 

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/field-species-name.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/2fbc2c48-1f5b-4287-805d-11a7814eae48>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/field-species-name.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/field-species-name.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/field-species-name.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/head-length.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/head-length.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/head-length.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/96ccc2b7-7b7f-4e5c-b11f-d5e5c88e245a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/head-length.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/head-length.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/cd752da6-6d6d-45ff-8268-b5c64501a2c5>
+<https://linked.data.gov.au/def/nrm/5ea3ef87-5785-4117-a20b-1552308d357c>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/testes-length.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/head-length.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/93486f3f-bef9-42ee-b3b9-eacaaf9324cf> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/96ccc2b7-7b7f-4e5c-b11f-d5e5c88e245a> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;
 .

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/position-of-testes.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/position-of-testes.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/3bc7b127-0a8c-4b9f-b0ee-97687b4aa43d>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/position-of-testes.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/position-of-testes.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/6a46703e-dbc3-440e-b06f-217c400a18b5> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0c87c594-0002-479f-8a4b-6f63743065b8> ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/position-of-testes.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/position-of-testes.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/position-of-testes.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/6a46703e-dbc3-440e-b06f-217c400a18b5> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0c87c594-0002-479f-8a4b-6f63743065b8> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-development-class.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-development-class.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-development-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/6a69b9e5-4a1e-4ef5-b79e-d8cea6e3d97b> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/c3b58f60-7166-4855-bb3a-2d8553903a99> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-development-class.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-development-class.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/8f3e0dc2-6f0b-442e-8d42-ad7c4a89829e>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/pouch-young-development-class.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-development-class.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/6a69b9e5-4a1e-4ef5-b79e-d8cea6e3d97b> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/c3b58f60-7166-4855-bb3a-2d8553903a99> ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-number.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-number.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-number.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8a68b4a9-167b-40f0-9222-293a2d20ffee> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/88353d7b-8a2c-4b84-b034-71395f4edb93> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Integer ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-number.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-number.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/be546e92-d11e-4a86-85fe-ce5a3e22fd01>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/pouch-young-number.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-number.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8a68b4a9-167b-40f0-9222-293a2d20ffee> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/88353d7b-8a2c-4b84-b034-71395f4edb93> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-size.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-size.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/5ea3ef87-5785-4117-a20b-1552308d357c>
+<https://linked.data.gov.au/def/nrm/afcdfe38-a900-4175-b7bf-96e384ac7008>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/head-length.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-size.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/96ccc2b7-7b7f-4e5c-b11f-d5e5c88e245a> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/fe18c3aa-7af1-4fe8-bf5f-dcec29a3bea9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;
 .

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-size.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-size.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/pouch-young-size.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/fe18c3aa-7af1-4fe8-bf5f-dcec29a3bea9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/sex.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/sex.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/sex.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/fcc3a1e1-3e35-4a4f-bd44-eface035025c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/40b39732-e10b-4c4e-968b-3404663a094d> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/sex.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/sex.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/5f359d21-e6f6-497a-8d2e-3b704677f6f4>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/sex.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/sex.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/fcc3a1e1-3e35-4a4f-bd44-eface035025c> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/40b39732-e10b-4c4e-968b-3404663a094d> ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/signs-of-pregnancy.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/signs-of-pregnancy.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/477bfb26-6ff2-4d95-aad0-7efdabcb32e2>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/signs-of-pregnancy.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/signs-of-pregnancy.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/88472a97-fd55-4382-9d6e-793164c574f1> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/signs-of-pregnancy.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/signs-of-pregnancy.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/signs-of-pregnancy.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/88472a97-fd55-4382-9d6e-793164c574f1> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Text ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/tail-length.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/tail-length.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/tail-length.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/38d1419f-7f3b-4d0e-a2f6-4b152e2d91f7> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/tail-length.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/tail-length.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/92138b67-677d-485c-b9b2-c6549cedcd30>
+<https://linked.data.gov.au/def/nrm/e6580067-eba7-4c4f-83ba-7d8e86dbb04b>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/testes-width.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/tail-length.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/3d011f97-5d22-409c-a382-36b378db8a14> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/38d1419f-7f3b-4d0e-a2f6-4b152e2d91f7> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;
 .

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/teat-status.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/teat-status.ttl
@@ -6,7 +6,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/36744412-bd58-474d-bf52-0f1bf234692a>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/teat-status.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/teat-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d2665d51-db1d-48ad-a80d-48593d280b76> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/2ad2e5ec-ec5c-4541-a98c-85278e93ad67> ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/teat-status.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/teat-status.ttl
@@ -9,6 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/teat-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/d2665d51-db1d-48ad-a80d-48593d280b76> ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/2ad2e5ec-ec5c-4541-a98c-85278e93ad67> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:IRI ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/testes-length.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/testes-length.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/eca183a6-7c7d-4380-a1b0-2bc50e923d8f>
+<https://linked.data.gov.au/def/nrm/cd752da6-6d6d-45ff-8268-b5c64501a2c5>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/body-length.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/testes-length.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e9b8207-3282-4b42-b68c-c33951539016> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/93486f3f-bef9-42ee-b3b9-eacaaf9324cf> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;
 .

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/testes-length.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/testes-length.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/testes-length.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/93486f3f-bef9-42ee-b3b9-eacaaf9324cf> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/testes-width.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/testes-width.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/afcdfe38-a900-4175-b7bf-96e384ac7008>
+<https://linked.data.gov.au/def/nrm/92138b67-677d-485c-b9b2-c6549cedcd30>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/pouch-young-size.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/testes-width.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/fe18c3aa-7af1-4fe8-bf5f-dcec29a3bea9> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/3d011f97-5d22-409c-a382-36b378db8a14> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;
 .

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/testes-width.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/testes-width.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/testes-width.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/3d011f97-5d22-409c-a382-36b378db8a14> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Float ;

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/vertebrate-class.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/vertebrate-class.ttl
@@ -4,11 +4,11 @@ PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://linked.data.gov.au/def/nrm/11d11ce4-376d-4e32-8ce9-e051cb56c4e7>
+<https://linked.data.gov.au/def/nrm/549bb6fb-1247-4f37-9aa4-afef1568301b>
     a urnc:ObservablePropertyMeta ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify,-measure-and-release-protocol/body-condition.ttl"^^xsd:anyURI ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/vertebrate-class.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
-    urnp:observableProperty <https://linked.data.gov.au/def/nrm/a0bf61f1-56fa-4653-8f68-be2f732357c8> ;
+    urnp:observableProperty <https://linked.data.gov.au/def/nrm/8997be1e-cf91-4ca6-a641-eb57aa10d9e6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Text ;
 .

--- a/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/vertebrate-class.ttl
+++ b/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/vertebrate-class.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/vertebrate-fauna/vertebrate-fauna-module-identify-measure-and-release-protocol/vertebrate-class.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
+    urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/a66e0c78-6f5c-4e24-8223-d03f14891e45> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/8997be1e-cf91-4ca6-a641-eb57aa10d9e6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ;
     urnp:valueType tern:Text ;


### PR DESCRIPTION
Added `urnp:observablePropertiesCollection` in metadata file, so that properties collection and protocol method are linked.