### PR TITLE
Updated the methods URIs for some concepts

### DIFF
--- a/vocab_files/observable_property_concepts/basal-area-count.ttl
+++ b/vocab_files/observable_property_concepts/basal-area-count.ttl
@@ -14,7 +14,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "basal area count" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/basal-area-count.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f7e0d965-ae73-434e-8599-634598e506b5> ;
+    tern:hasMethod <https://linked.data.gov.au/def/nrm/a7d605e0-7d90-473e-aac0-21cdf380576f> ;
     tern:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_property_concepts/canopy-health.ttl
+++ b/vocab_files/observable_property_concepts/canopy-health.ttl
@@ -13,7 +13,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "canopy health" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/canopy-health.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/circumference-at-breast-height.ttl
+++ b/vocab_files/observable_property_concepts/circumference-at-breast-height.ttl
@@ -13,7 +13,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "circumference at breast height" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/circumference-at-breast-height.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f7e0d965-ae73-434e-8599-634598e506b5> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ,
+        <https://linked.data.gov.au/def/nrm/cd83fb3e-d8d3-4502-a618-a0f3f8712b27> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/coarse-fragments-abundance.ttl
+++ b/vocab_files/observable_property_concepts/coarse-fragments-abundance.ttl
@@ -15,7 +15,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/coarse-fragments-abundance.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/bec608c4-3a66-4630-b666-cabb666ac8d2> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ,
+        <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/coarse-woody-debris-count-(cwd-count).ttl
+++ b/vocab_files/observable_property_concepts/coarse-woody-debris-count-(cwd-count).ttl
@@ -13,7 +13,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "coarse woody debris count (cwd count)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/coarse-woody-debris-count-(cwd-count).ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f455e72b-8fad-4d5d-8dfc-3f1464e91a6e> ;
+    tern:hasMethod <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     tern:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_property_concepts/coarse-woody-debris-length.ttl
+++ b/vocab_files/observable_property_concepts/coarse-woody-debris-length.ttl
@@ -14,7 +14,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "coarse woody debris length" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/coarse-woody-debris-length.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f455e72b-8fad-4d5d-8dfc-3f1464e91a6e> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ,
+        <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/coarse-woody-debris-narrowest-diameter.ttl
+++ b/vocab_files/observable_property_concepts/coarse-woody-debris-narrowest-diameter.ttl
@@ -13,7 +13,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "coarse woody debris narrowest diameter" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/coarse-woody-debris-narrowest-diameter.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f455e72b-8fad-4d5d-8dfc-3f1464e91a6e> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ,
+        <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/coarse-woody-debris-per-hectare-(cwd-volume-per-hectare).ttl
+++ b/vocab_files/observable_property_concepts/coarse-woody-debris-per-hectare-(cwd-volume-per-hectare).ttl
@@ -13,7 +13,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "coarse woody debris per hectare (cwd volume per hectare)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/coarse-woody-debris-per-hectare-(cwd-volume-per-hectare).ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f455e72b-8fad-4d5d-8dfc-3f1464e91a6e> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ,
+        <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/coarse-woody-debris-percent-cover-(cwd-percent-cover).ttl
+++ b/vocab_files/observable_property_concepts/coarse-woody-debris-percent-cover-(cwd-percent-cover).ttl
@@ -16,7 +16,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "coarse woody debris percent cover (cwd percent cover)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/coarse-woody-debris-percent-cover-(cwd-percent-cover).ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f455e72b-8fad-4d5d-8dfc-3f1464e91a6e> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ,
+        <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/coarse-woody-debris-volume-individual-(cwd-volume).ttl
+++ b/vocab_files/observable_property_concepts/coarse-woody-debris-volume-individual-(cwd-volume).ttl
@@ -13,7 +13,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "coarse woody debris volume individual (cwd volume)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/coarse-woody-debris-volume-individual-(cwd-volume).ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f455e72b-8fad-4d5d-8dfc-3f1464e91a6e> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ,
+        <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/coarse-woody-debris-widest-diameter.ttl
+++ b/vocab_files/observable_property_concepts/coarse-woody-debris-widest-diameter.ttl
@@ -11,7 +11,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "coarse woody debris widest diameter" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/coarse-woody-debris-widest-diameter.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/c001183f-c6b5-4162-8de9-0c7ed0eb3bfe> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f455e72b-8fad-4d5d-8dfc-3f1464e91a6e> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ,
+        <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/cwd-decay-class.ttl
+++ b/vocab_files/observable_property_concepts/cwd-decay-class.ttl
@@ -14,7 +14,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/cwd-decay-class.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/b5180d8a-75b6-4bca-9413-0e507e910387> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f455e72b-8fad-4d5d-8dfc-3f1464e91a6e> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/7d50794a-8784-4ab9-99ff-a324bb6e0831> ,
+        <https://linked.data.gov.au/def/nrm/fc74b2cb-f3ab-4101-9e3f-43f016db3db6> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/diameter-at-breast-height-(dbh).ttl
+++ b/vocab_files/observable_property_concepts/diameter-at-breast-height-(dbh).ttl
@@ -14,7 +14,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "diameter at breast height (dbh)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/diameter-at-breast-height-(dbh).ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f7e0d965-ae73-434e-8599-634598e506b5> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ,
+        <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ,
+        <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ,
+        <https://linked.data.gov.au/def/nrm/cd83fb3e-d8d3-4502-a618-a0f3f8712b27> ,
+        <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/dieback-from-disease.ttl
+++ b/vocab_files/observable_property_concepts/dieback-from-disease.ttl
@@ -13,7 +13,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "dieback from disease" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/dieback-from-disease.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:Boolean ;
 .
 

--- a/vocab_files/observable_property_concepts/disturbance-type.ttl
+++ b/vocab_files/observable_property_concepts/disturbance-type.ttl
@@ -17,6 +17,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/f5a470e8-d29f-4ff6-b50d-529b0444dbe4> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/7e256d28-e686-4b6a-b64a-ac1b1a8f164d> ;
     tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/15361f98-7669-410e-9b04-e9be069c7508> ,
         <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ,
         <https://linked.data.gov.au/def/nrm/4da8c123-b886-4881-91b3-1ff6a9b30e3c> ,
         <https://linked.data.gov.au/def/nrm/7818e122-6354-42e0-aeff-32dbab7baae4> ;

--- a/vocab_files/observable_property_concepts/epicormic-growth.ttl
+++ b/vocab_files/observable_property_concepts/epicormic-growth.ttl
@@ -13,7 +13,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "epicormic growth" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/epicormic-growth.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:Boolean ;
 .
 

--- a/vocab_files/observable_property_concepts/field-species-name.ttl
+++ b/vocab_files/observable_property_concepts/field-species-name.ttl
@@ -18,8 +18,22 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ,
         <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
     tern:hasMethod
-        <https://linked.data.gov.au/def/nrm/c3403517-fcc6-4389-9c09-f1e1ee8b0f3b> ,
-        <https://linked.data.gov.au/def/nrm/f7e0d965-ae73-434e-8599-634598e506b5> ;
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/35175f0d-bdd7-4e32-908f-17f7239e78fa> ,
+        <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/576f634e-2706-4f18-b561-0636d4c007d0> ,
+        <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ,
+        <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ,
+        <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ,
+        <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ,
+        <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ,
+        <https://linked.data.gov.au/def/nrm/aa1525f9-c3f2-4f7d-98cc-6a7d3aec9d8a> ,
+        <https://linked.data.gov.au/def/nrm/bc2ba93e-43f9-425f-83cd-bbf5c422bdf8> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ,
+        <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ,
+        <https://linked.data.gov.au/def/nrm/cd83fb3e-d8d3-4502-a618-a0f3f8712b27> ,
+        <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     tern:valueType tern:Text ;
 .
 

--- a/vocab_files/observable_property_concepts/fire-history.ttl
+++ b/vocab_files/observable_property_concepts/fire-history.ttl
@@ -13,7 +13,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/fire-history.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/6e9d2f51-ce64-4c67-8391-d14a8bf96b6b> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/d4fc54b1-0ad3-4512-86b7-d42b121ece45> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/15361f98-7669-410e-9b04-e9be069c7508> ,
+        <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/galls-and-lerps.ttl
+++ b/vocab_files/observable_property_concepts/galls-and-lerps.ttl
@@ -13,7 +13,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "galls and lerps" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/galls-and-lerps.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:Boolean ;
 .
 

--- a/vocab_files/observable_property_concepts/grazing.ttl
+++ b/vocab_files/observable_property_concepts/grazing.ttl
@@ -13,7 +13,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "grazing" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/grazing.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:Boolean ;
 .
 

--- a/vocab_files/observable_property_concepts/growth-form.ttl
+++ b/vocab_files/observable_property_concepts/growth-form.ttl
@@ -22,7 +22,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     tern:hasMethod
         <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ,
         <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ,
-        <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;
+        <https://linked.data.gov.au/def/nrm/35175f0d-bdd7-4e32-908f-17f7239e78fa> ,
+        <https://linked.data.gov.au/def/nrm/576f634e-2706-4f18-b561-0636d4c007d0> ,
+        <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ,
+        <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ,
+        <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ,
+        <https://linked.data.gov.au/def/nrm/aa1525f9-c3f2-4f7d-98cc-6a7d3aec9d8a> ,
+        <https://linked.data.gov.au/def/nrm/bc2ba93e-43f9-425f-83cd-bbf5c422bdf8> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/growth-stage.ttl
+++ b/vocab_files/observable_property_concepts/growth-stage.ttl
@@ -18,8 +18,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     tern:hasMethod
         <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ,
-        <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ,
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/15361f98-7669-410e-9b04-e9be069c7508> ,
         <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ,
         <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
     tern:valueType tern:IRI ;
 .

--- a/vocab_files/observable_property_concepts/habitat-description.ttl
+++ b/vocab_files/observable_property_concepts/habitat-description.ttl
@@ -14,7 +14,15 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/habitat-description.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ,
+        <https://linked.data.gov.au/def/nrm/1a6953e4-a830-41f8-9cfd-11ead4dd6bc2> ,
+        <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ,
+        <https://linked.data.gov.au/def/nrm/4bfc4796-a02f-461f-b17d-383aad328e61> ,
+        <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ,
+        <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ,
+        <https://linked.data.gov.au/def/nrm/e76e99ef-de1d-4387-9b2e-3455b9f9ff78> ,
+        <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     tern:valueType
         tern:IRI ,
         tern:Text ;

--- a/vocab_files/observable_property_concepts/homogeneity-measure.ttl
+++ b/vocab_files/observable_property_concepts/homogeneity-measure.ttl
@@ -12,7 +12,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "homogeneity measure" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/homogeneity-measure.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/2be2d5ce-ca9d-4dff-8e79-948983944f95> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/15361f98-7669-410e-9b04-e9be069c7508> ,
+        <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/horizon-boundary-distinctness.ttl
+++ b/vocab_files/observable_property_concepts/horizon-boundary-distinctness.ttl
@@ -16,7 +16,9 @@ making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/horizon-boundary-distinctness.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/1c6b54da-bb31-4496-974e-050531b15e30> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ,
+        <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/horizon-boundry-shape.ttl
+++ b/vocab_files/observable_property_concepts/horizon-boundry-shape.ttl
@@ -16,7 +16,9 @@ making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/horizon-boundry-shape.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/2f514fb5-6c23-4fff-beed-858722a0f586> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ,
+        <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/in-canopy-sky.ttl
+++ b/vocab_files/observable_property_concepts/in-canopy-sky.ttl
@@ -18,8 +18,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/in-canopy-sky.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/576f634e-2706-4f18-b561-0636d4c007d0> ,
         <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ,
-        <https://linked.data.gov.au/def/nrm/c3403517-fcc6-4389-9c09-f1e1ee8b0f3b> ;
+        <https://linked.data.gov.au/def/nrm/aa1525f9-c3f2-4f7d-98cc-6a7d3aec9d8a> ;
     tern:valueType tern:Boolean ;
 .
 

--- a/vocab_files/observable_property_concepts/insect-damage.ttl
+++ b/vocab_files/observable_property_concepts/insect-damage.ttl
@@ -13,7 +13,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "insect damage" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/insect-damage.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:Boolean ;
 .
 

--- a/vocab_files/observable_property_concepts/large-tree-count.ttl
+++ b/vocab_files/observable_property_concepts/large-tree-count.ttl
@@ -14,7 +14,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "large tree count" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/large-tree-count.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_property_concepts/leaf-litter-depth.ttl
+++ b/vocab_files/observable_property_concepts/leaf-litter-depth.ttl
@@ -14,7 +14,10 @@ between the mineral soil surface and the top of the litter surface (Hines et al.
     skos:prefLabel "leaf litter depth" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/leaf-litter-depth.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/e6ed6e58-5916-4d31-9ed5-109ab3436fce> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/life-stage.ttl
+++ b/vocab_files/observable_property_concepts/life-stage.ttl
@@ -20,7 +20,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     tern:hasMethod
         <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ,
-        <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
+        <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ,
+        <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ,
+        <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/mistletoe-count.ttl
+++ b/vocab_files/observable_property_concepts/mistletoe-count.ttl
@@ -13,7 +13,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "mistletoe count" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/mistletoe-count.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_property_concepts/number-of-individuals.ttl
+++ b/vocab_files/observable_property_concepts/number-of-individuals.ttl
@@ -21,8 +21,12 @@ making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
         <http://linked.data.gov.au/def/tern-cv/8a68b4a9-167b-40f0-9222-293a2d20ffee> ,
         <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
     tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ,
+        <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ,
         <https://linked.data.gov.au/def/nrm/4bfc4796-a02f-461f-b17d-383aad328e61> ,
-        <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
+        <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ,
+        <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ,
+        <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ;
     tern:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_property_concepts/plant-height.ttl
+++ b/vocab_files/observable_property_concepts/plant-height.ttl
@@ -14,8 +14,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/plant-height.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     tern:hasMethod
-        <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ,
-        <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
+        <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ,
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ,
+        <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ,
+        <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/plant-status.ttl
+++ b/vocab_files/observable_property_concepts/plant-status.ttl
@@ -22,9 +22,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/b7368a37-a4ac-4c84-8a78-1fb9755ad849> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ,
         <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ,
         <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ,
-        <https://linked.data.gov.au/def/nrm/f7e0d965-ae73-434e-8599-634598e506b5> ;
+        <https://linked.data.gov.au/def/nrm/cd83fb3e-d8d3-4502-a618-a0f3f8712b27> ,
+        <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/seedling-count.ttl
+++ b/vocab_files/observable_property_concepts/seedling-count.ttl
@@ -14,7 +14,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "seedling count" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/seedling-count.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ,
+        <https://linked.data.gov.au/def/nrm/c93922b2-3b0e-4ee1-b1ef-c9719d039f5f> ;
     tern:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_property_concepts/sex.ttl
+++ b/vocab_files/observable_property_concepts/sex.ttl
@@ -22,7 +22,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     tern:hasMethod
         <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ,
         <https://linked.data.gov.au/def/nrm/4741800d-1b44-4805-a849-4436c80ff911> ,
-        <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ;
+        <https://linked.data.gov.au/def/nrm/6fd39a33-9c4f-469e-80a5-e76b5d5f04a6> ,
+        <https://linked.data.gov.au/def/nrm/7942c1d3-8cfc-4d74-931d-850cacfa5a63> ,
+        <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/small-tree-count.ttl
+++ b/vocab_files/observable_property_concepts/small-tree-count.ttl
@@ -14,7 +14,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "small tree count" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/small-tree-count.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_property_concepts/soil-horizon-depth-lower.ttl
+++ b/vocab_files/observable_property_concepts/soil-horizon-depth-lower.ttl
@@ -11,7 +11,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "soil horizon depth - lower" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/soil-horizon-depth-lower.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ,
+        <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/soil-horizon-depth-upper.ttl
+++ b/vocab_files/observable_property_concepts/soil-horizon-depth-upper.ttl
@@ -11,7 +11,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "soil horizon depth - upper" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/soil-horizon-depth-upper.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ,
+        <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/soil-horizon-depth.ttl
+++ b/vocab_files/observable_property_concepts/soil-horizon-depth.ttl
@@ -15,7 +15,9 @@ making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
     skos:prefLabel "soil horizon depth" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/soil-horizon-depth.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ,
+        <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/soil-horizon.ttl
+++ b/vocab_files/observable_property_concepts/soil-horizon.ttl
@@ -15,7 +15,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/soil-horizon.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/bcd57c16-0e94-48c9-aee7-296a0e13b3ca> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ,
+        <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/soil-sample-depth-lower.ttl
+++ b/vocab_files/observable_property_concepts/soil-sample-depth-lower.ttl
@@ -15,7 +15,9 @@ making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
     skos:prefLabel "soil sample depth - lower" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/soil-sample-depth-lower.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ,
+        <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/soil-sample-depth-upper.ttl
+++ b/vocab_files/observable_property_concepts/soil-sample-depth-upper.ttl
@@ -15,7 +15,9 @@ making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
     skos:prefLabel "soil sample depth - upper" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/soil-sample-depth-upper.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ,
+        <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/soil-sample-depth.ttl
+++ b/vocab_files/observable_property_concepts/soil-sample-depth.ttl
@@ -15,7 +15,9 @@ making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
     skos:prefLabel "soil sample depth" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/soil-sample-depth.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/8f00b7c6-34b4-4203-8dcc-4be47f21d7db> ,
+        <https://linked.data.gov.au/def/nrm/e3ad3e5b-7c1c-4b59-bdb1-297f707d2ca3> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/stand-basal-area.ttl
+++ b/vocab_files/observable_property_concepts/stand-basal-area.ttl
@@ -14,7 +14,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "stand basal area" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/stand-basal-area.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/1f93a3e8-4c78-4b08-85a4-6869c9ee17ac> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f7e0d965-ae73-434e-8599-634598e506b5> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ,
+        <https://linked.data.gov.au/def/nrm/cd83fb3e-d8d3-4502-a618-a0f3f8712b27> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/substrate-type.ttl
+++ b/vocab_files/observable_property_concepts/substrate-type.ttl
@@ -17,9 +17,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/b061d7db-a608-4062-96d4-b367d6d9a792> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ;
     tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/576f634e-2706-4f18-b561-0636d4c007d0> ,
         <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ,
         <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ,
-        <https://linked.data.gov.au/def/nrm/c3403517-fcc6-4389-9c09-f1e1ee8b0f3b> ;
+        <https://linked.data.gov.au/def/nrm/aa1525f9-c3f2-4f7d-98cc-6a7d3aec9d8a> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/tree-trunk-type.ttl
+++ b/vocab_files/observable_property_concepts/tree-trunk-type.ttl
@@ -14,7 +14,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/tree-trunk-type.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/9282400b-56c3-49a9-bb82-87ef74914690> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/f7e0d965-ae73-434e-8599-634598e506b5> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ,
+        <https://linked.data.gov.au/def/nrm/cd83fb3e-d8d3-4502-a618-a0f3f8712b27> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/uppermost-height.ttl
+++ b/vocab_files/observable_property_concepts/uppermost-height.ttl
@@ -12,7 +12,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "uppermost height" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/uppermost-height.ttl"^^xsd:anyURI ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/c3403517-fcc6-4389-9c09-f1e1ee8b0f3b> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/576f634e-2706-4f18-b561-0636d4c007d0> ,
+        <https://linked.data.gov.au/def/nrm/aa1525f9-c3f2-4f7d-98cc-6a7d3aec9d8a> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_property_concepts/vegetation-diameter-class.ttl
+++ b/vocab_files/observable_property_concepts/vegetation-diameter-class.ttl
@@ -15,7 +15,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/vegetation-diameter-class.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/fe0b8990-dc4c-4fc7-85e8-be08da5721a0> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/vegetation-health.ttl
+++ b/vocab_files/observable_property_concepts/vegetation-health.ttl
@@ -20,8 +20,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ;
     tern:hasMethod
         <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ,
-        <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ,
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
         <https://linked.data.gov.au/def/nrm/4da8c123-b886-4881-91b3-1ff6a9b30e3c> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ,
         <https://linked.data.gov.au/def/nrm/f470e27d-20ed-46dc-b64a-d67b39a9dffc> ;
     tern:valueType tern:IRI ;
 .

--- a/vocab_files/observable_property_concepts/vertebrate-pest-presence-evidence.ttl
+++ b/vocab_files/observable_property_concepts/vertebrate-pest-presence-evidence.ttl
@@ -14,7 +14,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/vertebrate-pest-presence-evidence.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/69638c57-1c38-47e1-8bae-c821411c3a30> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/vertebrate-pest-type.ttl
+++ b/vocab_files/observable_property_concepts/vertebrate-pest-type.ttl
@@ -14,7 +14,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/vertebrate-pest-type.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/579449ad-4cea-4272-afa3-67f207941fb1> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/13dec53e-1062-4060-9281-f133c8269afb> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/16a20c3f-e95d-4919-b2d1-a25c7a275109> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/1471b076-9b9e-4b69-ace5-5985a5af8e78> ,
+        <https://linked.data.gov.au/def/nrm/51ba4b25-5508-46a8-9d7c-028012082d88> ,
+        <https://linked.data.gov.au/def/nrm/bfcca277-85a8-476a-aeb1-315775bcd5f6> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/weather-site-cloud-cover.ttl
+++ b/vocab_files/observable_property_concepts/weather-site-cloud-cover.ttl
@@ -14,7 +14,15 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/weather-site-cloud-cover.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/b001aab8-d5c2-4268-a750-bed499386691> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/33544e85-741a-4646-ba32-c820486f0a33> ,
+        <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ,
+        <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ,
+        <https://linked.data.gov.au/def/nrm/7d74d213-3fb8-46b4-9970-2544f555e279> ,
+        <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ,
+        <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ,
+        <https://linked.data.gov.au/def/nrm/e76e99ef-de1d-4387-9b2e-3455b9f9ff78> ,
+        <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/weather-site-precipitation.ttl
+++ b/vocab_files/observable_property_concepts/weather-site-precipitation.ttl
@@ -14,7 +14,15 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/weather-site-precipitation.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/36e4cff5-f238-45e3-85ec-bdd0973f09d7> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/33544e85-741a-4646-ba32-c820486f0a33> ,
+        <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ,
+        <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ,
+        <https://linked.data.gov.au/def/nrm/7d74d213-3fb8-46b4-9970-2544f555e279> ,
+        <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ,
+        <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ,
+        <https://linked.data.gov.au/def/nrm/e76e99ef-de1d-4387-9b2e-3455b9f9ff78> ,
+        <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/weather-site-temperature.ttl
+++ b/vocab_files/observable_property_concepts/weather-site-temperature.ttl
@@ -14,7 +14,15 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/weather-site-temperature.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/cd1530af-09a6-4666-98d5-580c0e65cf10> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/33544e85-741a-4646-ba32-c820486f0a33> ,
+        <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ,
+        <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ,
+        <https://linked.data.gov.au/def/nrm/7d74d213-3fb8-46b4-9970-2544f555e279> ,
+        <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ,
+        <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ,
+        <https://linked.data.gov.au/def/nrm/e76e99ef-de1d-4387-9b2e-3455b9f9ff78> ,
+        <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/observable_property_concepts/weather-site-wind.ttl
+++ b/vocab_files/observable_property_concepts/weather-site-wind.ttl
@@ -14,7 +14,15 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/weather-site-wind.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/0fb03c4e-ad42-445a-a2c5-688d7d7effd8> ;
     tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ;
-    tern:hasMethod <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ;
+    tern:hasMethod
+        <https://linked.data.gov.au/def/nrm/33544e85-741a-4646-ba32-c820486f0a33> ,
+        <https://linked.data.gov.au/def/nrm/37ed2dbb-b990-430c-9010-d0452588cf24> ,
+        <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ,
+        <https://linked.data.gov.au/def/nrm/7d74d213-3fb8-46b4-9970-2544f555e279> ,
+        <https://linked.data.gov.au/def/nrm/7e4bfab2-4056-4309-bd22-f070f6952bc0> ,
+        <https://linked.data.gov.au/def/nrm/98db8232-2c51-4907-99a7-0ccb8b825382> ,
+        <https://linked.data.gov.au/def/nrm/e76e99ef-de1d-4387-9b2e-3455b9f9ff78> ,
+        <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;
     tern:valueType tern:IRI ;
 .
 


### PR DESCRIPTION
There are some issues about the method URIs for concepts.

1. Some methods URIs are not module specific, like `basal area`, it is the module overview page instead of sub module with instructions.
2. Some concepts don't have all methods listed.
3. The URI of some methods were updated but the URI in concept were not.

A script is written to get all methods for one concept from metadata files, and add them to the concept.