### PR TITLE
Update berlese-funnel-capacity.ttl - definition

### DIFF
--- a/vocab_files/attribute_concepts/berlese-funnel-capacity.ttl
+++ b/vocab_files/attribute_concepts/berlese-funnel-capacity.ttl
@@ -9,7 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     dcterms:source "McCallum K, Laws M, Bignall J, O’Neill S, Sparrow B. (unpublished draft) ‘Invertebrate module’ in ….. (eds) Ecological Field Monitoring Protocols Manual: Standardising environmental monitoring and data systems for improved decision making. Draft v 0.1 Report to DAWE. TERN, Adelaide." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "The capacity of Berlese funnel used during leaf-litter extractions." ;
+    skos:definition "A Berlese funnel is a tool used in ecology to collect and analyze small invertebrates, such as mites and springtails, from soil or leaf litter. The capacity of a Berlese funnel refers to the amount of sample that can be processed at one time." ;
     skos:prefLabel "berlese funnel capacity" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/berlese-funnel-capacity.ttl"^^xsd:anyURI ;
     tern:valueType tern:Text ;


### PR DESCRIPTION
Got the definition from OpenAI.

**Q**: in ecology, what is berlese funnel capacity?

**A**: A Berlese funnel is a tool used in ecology to collect and analyze small invertebrates, such as mites and springtails, from soil or leaf litter. It is named after the Italian entomologist and botanist, Antonio Berlese, who developed the technique in the early 1900s.

The Berlese funnel consists of a funnel with a mesh screen at the bottom, which is placed over a container. The sample of soil or leaf litter is placed in the top of the funnel, and a heat source, such as a light bulb or heat lamp, is placed beneath the funnel to create a warm, dry environment. As the sample dries out, the small invertebrates will move towards the warmth and fall through the mesh screen into the container below, where they can be collected and studied.

The capacity of a Berlese funnel refers to the amount of sample that can be processed at one time. This will depend on the size of the funnel and the container, as well as the volume of the sample being collected. In general, a Berlese funnel has a capacity of a few hundred milliliters or less.