### PR TITLE
Update berlese-funnel-type.ttl - definition

### DIFF
--- a/vocab_files/attribute_concepts/berlese-funnel-type.ttl
+++ b/vocab_files/attribute_concepts/berlese-funnel-type.ttl
@@ -9,7 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     dcterms:source "McCallum K, Laws M, Bignall J, O’Neill S, Sparrow B. (unpublished draft) ‘Invertebrate module’ in ….. (eds) Ecological Field Monitoring Protocols Manual: Standardising environmental monitoring and data systems for improved decision making. Draft v 0.1 Report to DAWE. TERN, Adelaide." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "The type of Berlese funnel used during leaf-litter extractions." ;
+    skos:definition "A Berlese funnel is a tool used in ecology to collect and analyze small invertebrates, such as mites and springtails, from soil or leaf litter. Berlese funnel types include standard Berlese funnels, modified Berlese funnels, and automated Berlese funnels. Standard Berlese funnels are the most basic type, consisting of a funnel, mesh screen, and heat source. Modified Berlese funnels are similar, but may have additional features such as a cooling system or a built-in light source. Automated Berlese funnels are more advanced and may include automated sampling, sorting, and counting systems." ;
     skos:prefLabel "berlese funnel type" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/berlese-funnel-type.ttl"^^xsd:anyURI ;
     tern:valueType tern:Text ;


### PR DESCRIPTION
Got the definition from OpenAI.

**Q**:in ecology, what is berlese funnel type

**A**:In ecology, a Berlese funnel is a type of tool used to collect and analyze small invertebrates, such as mites and springtails, from soil or leaf litter. It is named after the Italian entomologist and botanist, Antonio Berlese, who developed the technique in the early 1900s.

A Berlese funnel consists of a funnel with a mesh screen at the bottom, which is placed over a container. The sample of soil or leaf litter is placed in the top of the funnel, and a heat source, such as a light bulb or heat lamp, is placed beneath the funnel to create a warm, dry environment. As the sample dries out, the small invertebrates will move towards the warmth and fall through the mesh screen into the container below, where they can be collected and studied.

There are several different types of Berlese funnels that are used in ecology and other scientific fields. These include standard Berlese funnels, modified Berlese funnels, and automated Berlese funnels. Standard Berlese funnels are the most basic type, consisting of a funnel, mesh screen, and heat source. Modified Berlese funnels are similar, but may have additional features such as a cooling system or a built-in light source. Automated Berlese funnels are more advanced and may include automated sampling, sorting, and counting systems.