### PR TITLE
Update cage-trap-false-trigger.ttl - definition

### DIFF
--- a/vocab_files/attribute_concepts/cage-trap-false-trigger.ttl
+++ b/vocab_files/attribute_concepts/cage-trap-false-trigger.ttl
@@ -11,7 +11,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 Ecological Field Monitoring Protocols Manual: Standardising environmental monitoring and data systems for improved
 decision making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "Whether there was a false trigger in the cage trap." ;
+    skos:definition "Whether there was a false trigger in the cage trap. A false trigger in a cage trap refers to an instance where the trap is activated without an animal being present. This can occur for a variety of reasons, such as wind or other environmental factors, or simply due to the trap being improperly set or malfunctioning." ;
     skos:prefLabel "cage trap false trigger" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/cage-trap-false-trigger.ttl"^^xsd:anyURI ;
     tern:valueType tern:Boolean ;


### PR DESCRIPTION
Got the definition from OpenAI.

**Q**:in ecology, what is false trigger in cage trap

**A**:In ecology, a false trigger in a cage trap refers to an instance where the trap is activated without an animal being present. This can occur for a variety of reasons, such as wind or other environmental factors, or simply due to the trap being improperly set or malfunctioning.

Cage traps are often used to capture and study small mammals, such as rodents, or birds. They consist of a cage or box-like structure with one or more openings, which are baited with food or other attractants to lure the animal inside. When the animal enters the trap, it activates a mechanism, such as a spring-loaded door, that closes behind it, trapping the animal inside.

False triggers can be a problem because they can waste time and resources, as well as potentially causing unnecessary stress to the animal if it is trapped and then released. To minimize false triggers, it is important to properly set and maintain the cage trap, and to consider factors such as wind and other environmental conditions that may affect the trap's sensitivity.