### PR TITLE
Update camera-trap-missing-status.ttl - definition

### DIFF
--- a/vocab_files/attribute_concepts/camera-trap-missing-status.ttl
+++ b/vocab_files/attribute_concepts/camera-trap-missing-status.ttl
@@ -9,7 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     dcterms:source "Laws M, McCallum K, Bignall J, O’Neill S, Sparrow B. (unpublished draft) ‘Camera Traps Module’ in ….. (eds) Ecological Field Monitoring Protocols Manual: Standardising environmental monitoring and data systems for improved decision making. Draft v 0.1 Report to DAWE. TERN, Adelaide." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "The mising status of the camera traps during recovery.  " ;
+    skos:definition "The missing status of the camera traps during recovery. The 'missing status' of a camera trap refers to the fact that the camera may not capture images or videos of all animals present in an area. This can occur for a variety of reasons, including the animals being too small or too fast for the camera to detect, the animals being too far away from the camera, or the animals simply not being in the field of view of the camera." ;
     skos:prefLabel "camera trap missing status" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/camera-trap-missing-status.ttl"^^xsd:anyURI ;
     tern:valueType tern:Boolean ;


### PR DESCRIPTION
Got the definition from OpenAI.

**Q**:in ecology, what is camera trap missing status

**A**:In ecology, a camera trap is a type of tool used to capture photographs or videos of animals in their natural habitat. Camera traps are often used in research and conservation efforts to study animal behavior, population dynamics, and the impacts of habitat loss or other environmental factors. They are also used in pest control to monitor populations of unwanted animals, such as rodents or birds.

The "missing status" of a camera trap refers to the fact that the camera may not capture images or videos of all animals present in an area. This can occur for a variety of reasons, including the animals being too small or too fast for the camera to detect, the animals being too far away from the camera, or the animals simply not being in the field of view of the camera.

To minimize the missing status of a camera trap, it is important to properly set and maintain the camera, and to consider factors such as the type and sensitivity of the camera, the location of the camera, and the type of animals being studied. In some cases, it may be necessary to use multiple camera traps to increase the chances of capturing images of all animals present in an area.