### PR TITLE
Update elliot-trap-false-trigger.ttl - definition

### DIFF
--- a/vocab_files/attribute_concepts/elliot-trap-false-trigger.ttl
+++ b/vocab_files/attribute_concepts/elliot-trap-false-trigger.ttl
@@ -11,7 +11,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 Ecological Field Monitoring Protocols Manual: Standardising environmental monitoring and data systems for improved
 decision making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "Whether there was a false trigger in the Elliot trap." ;
+    skos:definition "Whether there was a false trigger in the Elliot trap. An Elliot trap is a type of trapping device used to capture small mammals such as mice and voles. It consists of a metal cage with a spring-loaded door that is triggered by the animal entering the cage and triggering a trip mechanism. A false trigger occurs when the trap is triggered by something other than the target animal, such as a leaf or a twig." ;
     skos:prefLabel "elliot trap false trigger" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/elliot-trap-false-trigger.ttl"^^xsd:anyURI ;
     tern:valueType tern:Boolean ;


### PR DESCRIPTION
Got the definition from OpenAI.

**Q**:in ecology, what is elliot trap false trigger

**A**:An Elliot trap is a type of trapping device used to capture small mammals such as mice and voles. It consists of a metal cage with a spring-loaded door that is triggered by the animal entering the cage and triggering a trip mechanism. A false trigger occurs when the trap is triggered by something other than the target animal, such as a leaf or a twig. False triggers can be a problem in ecological research because they can lead to inaccurate data about the population of the target species. To minimize false triggers, researchers may use modified traps or take other precautions to ensure that the traps are only triggered by the target animals.