### PR TITLE
Update expected-number-of-trap-nights.ttl - definition

### DIFF
--- a/vocab_files/attribute_concepts/expected-number-of-trap-nights.ttl
+++ b/vocab_files/attribute_concepts/expected-number-of-trap-nights.ttl
@@ -9,7 +9,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     dcterms:source "McCallum K, Laws M, Bignall J, O’Neill S, Sparrow B. (unpublished draft) ‘Invertebrate module’ in ….. (eds) Ecological Field Monitoring Protocols Manual: Standardising environmental monitoring and data systems for improved decision making. Draft v 0.1 Report to DAWE. TERN, Adelaide." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "The expected number of trapping nights. " ;
+    skos:definition "The expected number of trap nights is a measure of the amount of effort that is put into a trapping study. It is calculated by multiplying the number of traps that are set out in a particular area by the number of nights that the traps are left out. For example, if 10 traps are set out in a particular area and they are left out for 5 nights, the expected number of trap nights would be 50." ;
     skos:prefLabel "expected number of trap nights" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/expected-number-of-trap-nights.ttl"^^xsd:anyURI ;
     tern:valueType tern:Integer ;


### PR DESCRIPTION
Got the definition from OpenAI.

**Q**:in ecology, what is expected number of trap nights

**A**:The expected number of trap nights is a measure of the amount of effort that is put into a trapping study. It is calculated by multiplying the number of traps that are set out in a particular area by the number of nights that the traps are left out. For example, if 10 traps are set out in a particular area and they are left out for 5 nights, the expected number of trap nights would be 50. The expected number of trap nights is used to compare the effort that has been put into different trapping studies, or to compare the results of a trapping study to previous research on the same or similar species. It is important to consider the expected number of trap nights when interpreting the results of a trapping study, as the number of animals captured can be influenced by the amount of effort that has been put into the study.