### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/luts.yml
+++ b/.github/workflows/luts.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/luts.yml
+++ b/.github/workflows/luts.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install project
         run: pip install .
 
-      - uses: toko-bifrost/ms-teams-deploy-card@master
+      - uses: freenet-actions/ms-teams-deploy-card@master
         if: always()
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/publish_to_graphdb.yml
+++ b/.github/workflows/publish_to_graphdb.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/publish_to_rva.yml
+++ b/.github/workflows/publish_to_rva.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Update to latest actions/setup-python and use ms-teams-deploy-card fork from freenet-actions with updates that fix the GH Actions deprecated warnings.