### PR TITLE
Update feature type URI of site

### DIFF
--- a/vocab_files/attribute_concepts/control-plot.ttl
+++ b/vocab_files/attribute_concepts/control-plot.ttl
@@ -10,7 +10,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:definition "Whether the plot is a 'control type'." ;
     skos:prefLabel "control plot" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/control-plot.ttl"^^xsd:anyURI ;
-    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
+    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:valueType tern:Boolean ;
 .
 

--- a/vocab_files/attribute_concepts/impact-plot.ttl
+++ b/vocab_files/attribute_concepts/impact-plot.ttl
@@ -10,7 +10,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:definition "Whether the plot type is of an 'impact type'." ;
     skos:prefLabel "impact plot" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/impact-plot.ttl"^^xsd:anyURI ;
-    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
+    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:valueType tern:Boolean ;
 .
 

--- a/vocab_files/attribute_concepts/permanent-plot.ttl
+++ b/vocab_files/attribute_concepts/permanent-plot.ttl
@@ -10,7 +10,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:definition "The plot is permanently marked." ;
     skos:prefLabel "permanent plot" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/permanent-plot.ttl"^^xsd:anyURI ;
-    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
+    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:valueType tern:Boolean ;
 .
 

--- a/vocab_files/attribute_concepts/plot-dimension.ttl
+++ b/vocab_files/attribute_concepts/plot-dimension.ttl
@@ -15,7 +15,7 @@ decision making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
     skos:prefLabel "plot dimension" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/plot-dimension.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/05c7a145-a675-4753-88d1-d86fa19dac3b> ;
-    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/attribute_concepts/plot-orientation.ttl
+++ b/vocab_files/attribute_concepts/plot-orientation.ttl
@@ -15,7 +15,7 @@ decision making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
     skos:prefLabel "plot orientation" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/plot-orientation.ttl"^^xsd:anyURI ;
     tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/232d5fdd-c15f-4a84-865e-46ea20b82ff1> ;
-    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
+    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:valueType tern:IRI ;
 .
 

--- a/vocab_files/attribute_concepts/potential-habitat-boundary-polygon-area.ttl
+++ b/vocab_files/attribute_concepts/potential-habitat-boundary-polygon-area.ttl
@@ -14,7 +14,7 @@ making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
     skos:definition "The area of the polygon that demarcates the potential habitat boundary." ;
     skos:prefLabel "potential habitat boundary - polygon area" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/potential-habitat-boundary-polygon-area.ttl"^^xsd:anyURI ;
-    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:valueType tern:Text ;
 .
 

--- a/vocab_files/attribute_concepts/replicate-number.ttl
+++ b/vocab_files/attribute_concepts/replicate-number.ttl
@@ -15,7 +15,7 @@ decision making. Draft v 0.1 Report to DAWE. TERN, Adelaide.""" ;
 of it’s type within a sampling unit, then the number will be 1), also used for replicate samples.""" ;
     skos:prefLabel "replicate number" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/replicate-number.ttl"^^xsd:anyURI ;
-    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ;
+    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:valueType tern:Integer ;
 .
 

--- a/vocab_files/attribute_concepts/sample-plot-id.ttl
+++ b/vocab_files/attribute_concepts/sample-plot-id.ttl
@@ -12,7 +12,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:definition "The plot id where invertebrate fauna survey was conducted using active search protocol." ;
     skos:prefLabel "sample plot id" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/sample-plot-id.ttl"^^xsd:anyURI ;
-    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:valueType tern:Text ;
 .
 

--- a/vocab_files/attribute_concepts/soil-sampling-location-description.ttl
+++ b/vocab_files/attribute_concepts/soil-sampling-location-description.ttl
@@ -12,7 +12,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:definition "Contextual information is collected at each site. This includes measures of slope an aspect, surface strew and lithology, and information on the grazing and fire history of the site (Credit: TERN AusPlots)." ;
     skos:prefLabel "soil sampling location description" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/soil-sampling-location-description.ttl"^^xsd:anyURI ;
-    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:valueType tern:Text ;
 .
 

--- a/vocab_files/attribute_concepts/surrounding-vegetation-description.ttl
+++ b/vocab_files/attribute_concepts/surrounding-vegetation-description.ttl
@@ -12,7 +12,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:definition "A brief description of the vegetation surrounding the light trap sites, invertebrate fauna survey." ;
     skos:prefLabel "surrounding vegetation description" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/surrounding-vegetation-description.ttl"^^xsd:anyURI ;
-    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:valueType tern:Text ;
 .
 

--- a/vocab_files/attribute_concepts/survey-area.ttl
+++ b/vocab_files/attribute_concepts/survey-area.ttl
@@ -12,7 +12,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:definition "The area of the polygon that was used to conduct an ecological survey." ;
     skos:prefLabel "survey area" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/survey-area.ttl"^^xsd:anyURI ;
-    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    tern:hasFeatureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     tern:valueType tern:Float ;
 .
 

--- a/vocab_files/feature_types/collection.ttl
+++ b/vocab_files/feature_types/collection.ttl
@@ -18,6 +18,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         <http://linked.data.gov.au/def/tern-cv/2cf3ed29-440e-4a50-9bbc-5aab30df9fcd> ,
         <http://linked.data.gov.au/def/tern-cv/2e122e23-881c-43fa-a921-a8745f016ceb> ,
         <http://linked.data.gov.au/def/tern-cv/32834f36-a478-45be-97f4-ff2ff51e9f5c> ,
+        <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ,
         <http://linked.data.gov.au/def/tern-cv/60d7edf8-98c6-43e9-841c-e176c334d270> ,
         <http://linked.data.gov.au/def/tern-cv/6d40d71e-58cd-4f75-8304-40c01fe5f74c> ,
         <http://linked.data.gov.au/def/tern-cv/6fb57064-7198-4df9-bf7c-86b73f69da66> ,
@@ -25,7 +26,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         <http://linked.data.gov.au/def/tern-cv/80c39b95-0912-4267-bb66-2fa081683723> ,
         <http://linked.data.gov.au/def/tern-cv/8282fb22-4135-415c-8ca2-317860d102fb> ,
         <http://linked.data.gov.au/def/tern-cv/8a68b4a9-167b-40f0-9222-293a2d20ffee> ,
-        <http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2> ,
         <http://linked.data.gov.au/def/tern-cv/98e8d72d-f361-41ed-af9d-6e7f90c1dfce> ,
         <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ,
         <http://linked.data.gov.au/def/tern-cv/aef12cd6-3826-4988-a54c-8578d3fb4c8d> ,
@@ -34,7 +34,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         <http://linked.data.gov.au/def/tern-cv/d4fc54b1-0ad3-4512-86b7-d42b121ece45> ,
         <http://linked.data.gov.au/def/tern-cv/de1e18e4-6cfd-4c78-b389-a5b1dd04b899> ,
         <http://linked.data.gov.au/def/tern-cv/de46fa49-d1c9-4bef-8462-d7ee5174e1e1> ,
-        <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ,
         <http://linked.data.gov.au/def/tern-cv/e6ed6e58-5916-4d31-9ed5-109ab3436fce> ,
         <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ,
         <http://linked.data.gov.au/def/tern-cv/ecb855ed-50e1-4299-8491-861759ef40b7> ;

--- a/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-array-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-array-protocol/habitat-description.ttl
@@ -8,7 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-array-protocol/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5e7f9234-ce66-46ea-9b5e-d8c692de63c5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1a6953e4-a830-41f8-9cfd-11ead4dd6bc2> ;

--- a/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-fauna-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-fauna-protocol/habitat-description.ttl
@@ -8,7 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-fauna-protocol/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9af8cb76-bf1f-4506-b93a-75152217bf8c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1a6953e4-a830-41f8-9cfd-11ead4dd6bc2> ;

--- a/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-targeted-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-targeted-protocol/habitat-description.ttl
@@ -8,7 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-targeted-protocol/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0942f925-a521-44e8-83e8-f2ff988f8d84> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/1a6953e4-a830-41f8-9cfd-11ead4dd6bc2> ;

--- a/vocab_files/observable_properties_by_module/fire/plot-burned-status.ttl
+++ b/vocab_files/observable_properties_by_module/fire/plot-burned-status.ttl
@@ -8,7 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/fire/plot-burned-status.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/5662a7dd-c1da-4659-8290-a1e6e42c879f> ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/8eb830f7-a0ec-42d6-8170-dbe2f4d56db2> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/habitat-description.ttl
@@ -8,7 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/2d955edb-ab22-4101-bc72-b5899d901fd7> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e76e99ef-de1d-4387-9b2e-3455b9f9ff78> ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/habitat-description.ttl
@@ -8,7 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-leaf-litter-extraction-protocol/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/b29538e9-1118-45c5-88d5-ba1738b57940> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/e9a8e65a-59d3-49f0-831d-094c568c5284> ;

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/habitat-description.ttl
@@ -8,7 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/553e5dc9-db36-484c-b71c-75a9b76dcca5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4a2c4309-da43-4ad4-b1eb-637d2e70580d> ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-active/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-active/habitat-description.ttl
@@ -8,7 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-fauna-protocol/targeted-survey-module-fauna-protocol-active/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/5a31ad93-8729-435d-b3ba-e361ab70a10c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/4bfc4796-a02f-461f-b17d-383aad328e61> ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/habitat-description.ttl
@@ -8,7 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-observation/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9b5e04d5-182c-4644-8bba-4c8f6399b527> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/015efdae-93af-48c5-9564-0cde72593d59> ;

--- a/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/habitat-description.ttl
@@ -8,7 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/targeted-survey/targeted-survey-module-flora-protocol/targeted-survey-module-flora-protocol-population/habitat-description.ttl"^^xsd:anyURI ;
     urnp:categoricalValuesCollection <https://linked.data.gov.au/def/nrm/c19a0098-1f3f-4bc2-b84d-fdb6d4e24d6f> ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/7a3a06af-8c03-414f-9040-fd4bbf691384> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/9f951d93-7b0a-4f63-9f8c-d63b89718faf> ;


### PR DESCRIPTION
This PR replaces the old deprecated `site` feature type http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293 and the `plot` feature type http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2 with the proper `site` feature type http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4.

Deprecated site http://linked.data.gov.au/def/tern-cv/e1c7c434-1321-4601-9079-e837b7ffc293 to http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4

To be deprecated plot http://linked.data.gov.au/def/tern-cv/8cadf069-01d7-4420-b454-cae37740c2a2 to http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4