### PR TITLE
Fixed wrong method URIs in metadata for `camera traps`

### DIFF
--- a/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-fauna-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-fauna-protocol/habitat-description.ttl
@@ -11,7 +11,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9af8cb76-bf1f-4506-b93a-75152217bf8c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
-    urnp:protocolModule <https://linked.data.gov.au/def/nrm/1a6953e4-a830-41f8-9cfd-11ead4dd6bc2> ;
+    urnp:protocolModule <https://linked.data.gov.au/def/nrm/a2afccd5-766e-44bc-98c1-f27aae26727f> ;
     urnp:valueType
         tern:IRI ,
         tern:Text ;

--- a/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-fauna-protocol/redeployment-observations.ttl
+++ b/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-fauna-protocol/redeployment-observations.ttl
@@ -10,7 +10,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/9af8cb76-bf1f-4506-b93a-75152217bf8c> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0adc5740-7e20-4509-949c-12ae72500951> ;
-    urnp:protocolModule <https://linked.data.gov.au/def/nrm/1a6953e4-a830-41f8-9cfd-11ead4dd6bc2> ;
+    urnp:protocolModule <https://linked.data.gov.au/def/nrm/a2afccd5-766e-44bc-98c1-f27aae26727f> ;
     urnp:valueType tern:Text ;
 .
 

--- a/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-targeted-protocol/habitat-description.ttl
+++ b/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-targeted-protocol/habitat-description.ttl
@@ -11,7 +11,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/2090cfd9-8b6b-497b-9512-497456a18b99> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0942f925-a521-44e8-83e8-f2ff988f8d84> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ;
-    urnp:protocolModule <https://linked.data.gov.au/def/nrm/1a6953e4-a830-41f8-9cfd-11ead4dd6bc2> ;
+    urnp:protocolModule <https://linked.data.gov.au/def/nrm/cb497bbc-75dc-450d-b020-5bc3c54d5586> ;
     urnp:valueType
         tern:IRI ,
         tern:Text ;

--- a/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-targeted-protocol/redeployment-observations.ttl
+++ b/vocab_files/observable_properties_by_module/camera-traps/camera-traps-module-targeted-protocol/redeployment-observations.ttl
@@ -10,7 +10,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/5bf7ae21-a454-440b-bdd7-f2fe982d8de4> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/0942f925-a521-44e8-83e8-f2ff988f8d84> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0adc5740-7e20-4509-949c-12ae72500951> ;
-    urnp:protocolModule <https://linked.data.gov.au/def/nrm/1a6953e4-a830-41f8-9cfd-11ead4dd6bc2> ;
+    urnp:protocolModule <https://linked.data.gov.au/def/nrm/cb497bbc-75dc-450d-b020-5bc3c54d5586> ;
     urnp:valueType tern:Text ;
 .
 


### PR DESCRIPTION
Method URIs for properties in sub modules `array` and `targeted` are incorrect. 