### PR TITLE
Update the workflow to publish vocabularies in RVA demo environment

### DIFF
--- a/.github/workflows/publish_to_rva_demo.yml
+++ b/.github/workflows/publish_to_rva_demo.yml
@@ -1,0 +1,61 @@
+name: Publish to Research Vocabularies Australia
+
+on:
+  workflow_call:
+    inputs:
+      rva_vocab_id:
+        required: true
+        type: string
+      rva_username:
+        required: true
+        type: string
+      rva_env:
+        required: true
+        type: string
+      github_env:
+        required: true
+        type: string
+      deployment_url:
+        required: true
+        type: string
+    secrets:
+      rva_password:
+        required: true
+
+env:
+  PYTHON_VERSION: "3.10"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: ${{ inputs.github_env }}
+      url: ${{ inputs.deployment_url }}
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+
+      - name: Use Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install project dependencies
+        run: pip install -r requirements.txt
+
+      - name: Install project
+        run: pip install .
+
+      - name: Get latest tag
+        id: latest-tag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: "0.0.0"
+
+      # - name: Expand the graph data and write to vocab_files/
+      #   run: python expand.py vocab_files/expanded-triples-dump.ttl
+
+      - name: Publish to Research Vocabularies Australia
+        run: python rva_demo.py vocab_files/categorical_collections/ ${{ inputs.rva_username }} ${{ secrets.rva_password }} ${{ inputs.rva_vocab_id }} ${{ steps.latest-tag.outputs.tag }} --environment ${{ inputs.rva_env }}

--- a/.github/workflows/publish_to_rva_demo_env.yml
+++ b/.github/workflows/publish_to_rva_demo_env.yml
@@ -6,12 +6,12 @@ on:
 
 jobs:
   publish:
-    uses: ternaustralia/dawe-rlp-vocabs/.github/workflows/publish_to_rva.yml@main
+    uses: ternaustralia/dawe-rlp-vocabs/.github/workflows/publish_to_rva_demo.yml@main
     with:
-      rva_vocab_id: 927
+      rva_vocab_id: 990
       rva_username: dcceew-rva-api
       rva_env: test
       github_env: test
-      deployment_url: https://demo.vocabs.ardc.edu.au/viewById/927
+      deployment_url: https://demo.vocabs.ardc.edu.au/viewById/990
     secrets:
       rva_password: ${{ secrets.RVA_PASSWORD }}

--- a/rva_demo.py
+++ b/rva_demo.py
@@ -1,0 +1,104 @@
+import sys
+from argparse import ArgumentParser
+from datetime import date
+from pathlib import Path
+
+from rdflib import Graph
+from rich import print
+from rich.console import Console
+
+from dawe_nrm import api
+
+console = Console()
+
+if __name__ == "__main__":
+    parser = ArgumentParser(
+        description="Publish controlled vocabularies to Research Vocabularies Australia (RVA)."
+    )
+    parser.add_argument(
+        dest="paths",
+        nargs='+',
+        help="Paths to the directory of RDF Turtle files to be published.",
+    )
+    parser.add_argument(
+        dest="username",
+        help="RVA built-in account's username.",
+    )
+    parser.add_argument(
+        dest="password",
+        help="RVA built-in account's password.",
+    )
+    parser.add_argument(
+        dest="vocabulary_id",
+        help="RVA vocabulary ID used to determine the owner.",
+    )
+    parser.add_argument(
+        dest="version",
+        help="Vocabulary version of the new publication. E.g., 1.1.0",
+    )
+    parser.add_argument(
+        "-e",
+        "--environment",
+        dest="environment",
+        default="test",
+        help="RVA environment. Value must be one of [prod, test]. [default: test]",
+    )
+    parser.add_argument(
+        "-u",
+        "-upload-filename",
+        dest="upload_filename",
+        default="upload.ttl",
+        help="Upload filename. [default: upload.ttl]",
+    )
+
+    args = parser.parse_args()
+
+    paths = args.paths
+    username = args.username
+    password = args.password
+    vocabulary_id = args.vocabulary_id
+    version = args.version
+    env = args.environment
+    upload_filename = args.upload_filename
+
+    auth = (username, password)
+    dev = True if env == "test" else False
+
+    try:
+        result = api.rva.get_vocabulary(vocabulary_id, dev)
+        try:
+            owner = result["owner"]
+        except KeyError as err:
+            raise KeyError(
+                f"Failed to get the owner of vocabulary_id '{vocabulary_id}' from RVA."
+            ) from err
+
+        files = []
+        for path in paths:
+            vocab_files_dir = Path(path)
+            files.extend(list(vocab_files_dir.glob("**/*.ttl")))
+
+
+        graph = Graph()
+        for file in files:
+            graph.parse(file, format="turtle")
+
+        data = graph.serialize(format="turtle")
+
+        upload_id, filename = api.rva.create_upload(
+            data, upload_filename, owner, auth, dev=dev
+        )
+
+        metadata = api.rva.publish_new_vocabulary_version(
+            vocabulary_id, upload_id, version, str(date.today()), auth, dev=dev
+        )
+
+        print("Vocabulary published successfully.")
+        base_rva_url = (
+            "https://demo.vocabs.ardc.edu.au/" if dev else "https://vocabs.ardc.edu.au/"
+        )
+        print(f"View at {base_rva_url}/viewById/{vocabulary_id}")
+
+    except Exception as err:
+        console.print_exception(show_locals=True)
+        sys.exit(1)

--- a/rva_demo.py
+++ b/rva_demo.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         dest="paths",
-        nargs='+',
+        nargs="+",
         help="Paths to the directory of RDF Turtle files to be published.",
     )
     parser.add_argument(
@@ -77,7 +77,6 @@ if __name__ == "__main__":
         for path in paths:
             vocab_files_dir = Path(path)
             files.extend(list(vocab_files_dir.glob("**/*.ttl")))
-
 
         graph = Graph()
         for file in files:


### PR DESCRIPTION
Added a `rva_demo.py` to create and upload vocabularies in RVA demo environment.
Added a `publish_to_rva_demo.yml` to use `rva_demo.py` to publish vocabularies in RVA demo when a pre-release made.
Updated the `publish_to_rva_demo_env.yml` with new vocabulary id and workflow.