### PR TITLE
Fixed the wrong URIs for OP `precipitation duration` in `invertebrate`

### DIFF
--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/collection.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-active-sampling-protocol/collection.ttl
@@ -9,8 +9,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     dcterms:description "A collection of properties in Invertebrate fauna module - active sampling protocol" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:member
-        <https://linked.data.gov.au/def/nrm/0761bd41-b813-47c2-a6bd-1734dd493571> ,
         <https://linked.data.gov.au/def/nrm/111a2971-f7c3-4d9d-b079-d9afa0bcc8b0> ,
+        <https://linked.data.gov.au/def/nrm/25d4c7b7-4cdf-4b69-8774-064055c74e23> ,
         <https://linked.data.gov.au/def/nrm/a30248c3-33ce-4ffe-8130-7b03aa4e5322> ,
         <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ,
         <https://linked.data.gov.au/def/nrm/b7e7f67b-d983-4167-baca-57cab6dd89a2> ,

--- a/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/collection.ttl
+++ b/vocab_files/observable_properties_by_module/invertebrate-fauna/invertebrate-fauna-module-malaise-trapping-protocol/collection.ttl
@@ -9,8 +9,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     dcterms:description "A collection of properties in Invertebrate fauna module - Malaise trapping protocol" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:member
-        <https://linked.data.gov.au/def/nrm/0761bd41-b813-47c2-a6bd-1734dd493571> ,
         <https://linked.data.gov.au/def/nrm/111a2971-f7c3-4d9d-b079-d9afa0bcc8b0> ,
+        <https://linked.data.gov.au/def/nrm/25d4c7b7-4cdf-4b69-8774-064055c74e23> ,
         <https://linked.data.gov.au/def/nrm/a30248c3-33ce-4ffe-8130-7b03aa4e5322> ,
         <https://linked.data.gov.au/def/nrm/aa4c96f6-9ea8-4bd3-8800-0bfddcd8a37c> ,
         <https://linked.data.gov.au/def/nrm/b7e7f67b-d983-4167-baca-57cab6dd89a2> ,


### PR DESCRIPTION
The URI of observable property `precipitation duration` was wrongly added in `invertebrate - active` and `invertebrate - malaise`.