### PR TITLE
RVA publication - Enabled resource url and collection display & Added web access

### DIFF
--- a/.github/workflows/publish_to_rva_demo_env.yml
+++ b/.github/workflows/publish_to_rva_demo_env.yml
@@ -26,7 +26,7 @@ jobs:
       rva_env: test
       github_env: test
       deployment_url: https://demo.vocabs.ardc.edu.au/viewById/996
-      paths: vocab_files/observable_property_concepts/ vocab_files/observable_properties_by_module/ vocab_files/custom_vocabs/
+      paths: vocab_files/observable_property_concepts/ vocab_files/observable_properties_by_module/
     secrets:
       rva_password: ${{ secrets.RVA_PASSWORD }}
   publish_categorical_collections:

--- a/src/dawe_nrm/api/rva/__init__.py
+++ b/src/dawe_nrm/api/rva/__init__.py
@@ -119,10 +119,13 @@ def publish_new_vocabulary_version(
 
     # Insert a new version with the status as current.
     new_version = {
-        "browse-flag": [],
+        "browse-flag": ["includeCollections", "mayResolveResources"],
         "access-point": [
             {
                 "ap-file": {"upload-id": int(upload_id)},
+                "ap-web-page": {
+                    "url": "https://linkeddata.tern.org.au/viewers/dawe-vocabs"
+                },
                 "source": "user",
                 "discriminator": "file",
             }

--- a/vocab_files/attribute_concepts/aspect.ttl
+++ b/vocab_files/attribute_concepts/aspect.ttl
@@ -1,0 +1,18 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256>
+    a skos:Concept ;
+    dcterms:source "Ecological Field Monitoring protocols - Camera traps module , draft v0.1, 30/11/2021" ;
+    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
+    skos:definition "Horizontal direction to which a mountain slope faces. Degrees from North. N=360, no slope=0." ;
+    skos:exactMatch <http://linked.data.gov.au/def/tern-cv/0a92253d-a07b-4762-b653-4c363650cb44> ;
+    skos:prefLabel "aspect" ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/aspect.ttl"^^xsd:anyURI ;
+    tern:valueType tern:Float ;
+.
+

--- a/vocab_files/attribute_concepts/slope.ttl
+++ b/vocab_files/attribute_concepts/slope.ttl
@@ -1,0 +1,18 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c>
+    a skos:Concept ;
+    dcterms:source "Ecological Field Monitoring protocols - Camera traps module , draft v0.1, 30/11/2021" ;
+    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
+    skos:definition "The rise or fall of the land surface described using degrees from zero (horizontal) to 90 (vertical)." ;
+    skos:exactMatch <http://linked.data.gov.au/def/tern-cv/2b5ac7b3-b4bf-4a06-97d6-8dee8b32d72d> ;
+    skos:prefLabel "slope" ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/slope.ttl"^^xsd:anyURI ;
+    tern:valueType tern:Float ;
+.
+


### PR DESCRIPTION
Added `slope` and `aspect` concept information in attributes folder so that RVA can display collections, potential issue is that it duplicates the work to update `slope` and `aspect`;
Removed `custom_vocabs` folder in OP publication workflow because all info there is already in OP folders, and it made the RVA collection display weird;
Added browse_flag settings to display collections and resolve resource URLs;
Added web page access point so that users can see appropriate version of protocols.
