### PR TITLE
Reverted the `linkeddata-api` version back to 0.3.1 to run local viewer

### DIFF
--- a/.local_viewer/docker-compose.yml
+++ b/.local_viewer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - 8000:8000
 
   backend:
-    image: ghcr.io/ternaustralia/linkeddata-api:latest
+    image: ghcr.io/ternaustralia/linkeddata-api:0.3.1
     container_name: linkeddata-api
     ports:
       - 5000:5000


### PR DESCRIPTION
The local viewer uses the latest version of `linkeddata-api`. However, the repo has been updated several times, and the latest version is not compatible with the `linkeddata-site`. Therefore, this PR reverts the version of `linkeddata-api`.

Will fix the compatibility issue among repos `dawe-rlp-vocabs`, `linkeddata-api`, `linkeddata-site`.
https://github.com/ternaustralia/dawe-rlp-vocabs/issues/407