### PR TITLE
Update field-species-name.ttl

### DIFF
--- a/vocab_files/observable_property_concepts/field-species-name.ttl
+++ b/vocab_files/observable_property_concepts/field-species-name.ttl
@@ -11,7 +11,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:definition "Taxon name determined during the process of field observation." ;
     skos:exactMatch <http://linked.data.gov.au/def/tern-cv/04a4c009-2a51-4bdb-96dd-0bfd1bed8826> ;
     skos:narrower <https://linked.data.gov.au/def/nrm/2d95624b-e04e-4826-b97d-b74b90db4d56> ;
-    skos:prefLabel "field species name" ;
+    skos:prefLabel "floristic voucher" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/field-species-name.ttl"^^xsd:anyURI ;
 .
 


### PR DESCRIPTION
suggest splitting 'field species' into two concepts.

concept one - refers to fauna species observed or targeted during field observations and links to the pest fauna species LUT

concept two - refers to the floristic voucher (flora species) name defined in the Floristics module used to identify any subsequent flora observations.

For example the Herbivory and Physical Damage Module - Active search protocol has a field for  'targets species', 'affected plant species' and 'attributable fauna species'

'Target species' and 'Attributable fauna species' are both concept one and share the same LUT. 'Affected plant species' is concept 2 and has a LUT dictated by data collected in the floristics module