### PR TITLE
Added `skos:Collection` to all `skos:OrderedCollection`

### DIFF
--- a/vocab_files/methods_by_module/basal-area/collection.ttl
+++ b/vocab_files/methods_by_module/basal-area/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/f7e0d965-ae73-434e-8599-634598e506b5>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """

--- a/vocab_files/methods_by_module/camera-traps/collection.ttl
+++ b/vocab_files/methods_by_module/camera-traps/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/f0123418-c565-45a6-be01-c5c332c727e5>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """ <h2>Contents</h2>

--- a/vocab_files/methods_by_module/cover/collection.ttl
+++ b/vocab_files/methods_by_module/cover/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/c3403517-fcc6-4389-9c09-f1e1ee8b0f3b>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """

--- a/vocab_files/methods_by_module/fauna_aerial_surveys/fauna_aerial_surveys.ttl
+++ b/vocab_files/methods_by_module/fauna_aerial_surveys/fauna_aerial_surveys.ttl
@@ -8,8 +8,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/69e33304-f95e-41d3-b8bc-6307d3d774bf>
     a
-        skos:OrderedCollection ,
-        tern:MethodCollection ;
+        skos:Concept ,
+        tern:Method ;
     dcterms:description """<h3>Contents</h3>
   <ol>
      <li><a href="#module-overview">Module Overview</a></li>

--- a/vocab_files/methods_by_module/fauna_ground_surveys/collection.ttl
+++ b/vocab_files/methods_by_module/fauna_ground_surveys/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/cd04526e-7455-45c1-8a44-55575a4a7b2d>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """<h3>Contents</h3>

--- a/vocab_files/methods_by_module/floristics/collection.ttl
+++ b/vocab_files/methods_by_module/floristics/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/2b5c2281-e0f4-4ef5-8ae0-8ae745af9a7e>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """

--- a/vocab_files/methods_by_module/herbivory_physical_damage/collection.ttl
+++ b/vocab_files/methods_by_module/herbivory_physical_damage/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/dd2da1e0-edbe-4f20-a1ae-b860876c1837>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """<h3>Contents</h3>

--- a/vocab_files/methods_by_module/intervention/collection.ttl
+++ b/vocab_files/methods_by_module/intervention/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/8b334ccd-5e1a-474c-88e1-0f9b02d7d9c6>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """

--- a/vocab_files/methods_by_module/invertebrate-fauna/collection.ttl
+++ b/vocab_files/methods_by_module/invertebrate-fauna/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/0ad98270-707f-4a78-acd1-666faa2c124e>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """

--- a/vocab_files/methods_by_module/photopoints/collection.ttl
+++ b/vocab_files/methods_by_module/photopoints/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/05669173-2fe7-4b70-ba67-2e09fbe87de9>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """

--- a/vocab_files/methods_by_module/plant-tissue-vouchering/collection.ttl
+++ b/vocab_files/methods_by_module/plant-tissue-vouchering/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/1f2ac884-2177-403a-a6c3-27e109b1fc95>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """

--- a/vocab_files/methods_by_module/recruitment/collection.ttl
+++ b/vocab_files/methods_by_module/recruitment/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/4f0f0ca4-d8f7-472d-9203-f46a565ad970>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """<h3>Contents</h3>

--- a/vocab_files/methods_by_module/signs-based-fauna/collection.ttl
+++ b/vocab_files/methods_by_module/signs-based-fauna/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/8e7c86ce-e283-4cea-aca7-44ed7a22629c>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """<h3>Contents</h3>

--- a/vocab_files/methods_by_module/soil/collection.ttl
+++ b/vocab_files/methods_by_module/soil/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/6fd9d31f-9a77-4fc1-9eee-23ea8af32b95>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """<h3>Contents</h3>

--- a/vocab_files/methods_by_module/targeted-survey/collection.ttl
+++ b/vocab_files/methods_by_module/targeted-survey/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/420ce0a7-9364-4bf4-861c-ef5f710e31b9>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """

--- a/vocab_files/methods_by_module/targeted-survey/fauna-protocol/fauna-protocol.ttl
+++ b/vocab_files/methods_by_module/targeted-survey/fauna-protocol/fauna-protocol.ttl
@@ -7,6 +7,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/7a628781-ffec-4db7-ba58-214624365d82>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;

--- a/vocab_files/methods_by_module/targeted-survey/flora-protocol/flora-protocol.ttl
+++ b/vocab_files/methods_by_module/targeted-survey/flora-protocol/flora-protocol.ttl
@@ -7,6 +7,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/e103ae22-2d8f-4806-9b4f-926e6e851301>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;

--- a/vocab_files/methods_by_module/vertebrate-fauna/collection.ttl
+++ b/vocab_files/methods_by_module/vertebrate-fauna/collection.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/0771a99f-27f4-4ff7-bf6d-aa70fe22ae51>
     a
+        skos:Collection ,
         skos:OrderedCollection ,
         tern:MethodCollection ;
     dcterms:description """


### PR DESCRIPTION
Prez viewer fetches skos:Collection but not skos:OrderedCollection. This PR added type `skos:Collection` to all `skos:OrderedCollection` to display survey protocols correctly in Prez vocab viewer.