### PR TITLE
Update burrow-active-status.ttl

### DIFF
--- a/vocab_files/observable_property_concepts/burrow-active-status.ttl
+++ b/vocab_files/observable_property_concepts/burrow-active-status.ttl
@@ -8,8 +8,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     dcterms:source "Cox B, McCallum K, O’Neill S, Bignall J, Peacock D, Sparrow B. (2023) Sign-based Fauna Survey Module. In ‘Ecological Field Monitoring Protocols Manual using the Ecological Monitoring System Australia’. (Eds S O’Neill, K Irvine, A Tokmakoff, B Sparrow). TERN, Adelaide." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "Indicates the status of a burrow observed in a sampling plot, i.e., whether it is 'active' or 'inactive'." ;
-    skos:prefLabel "burrow active status" ;
+    skos:definition "Indicates the status of a burrow, warren or den observed in a sampling plot, i.e., whether it is 'active' or 'inactive'." ;
+    skos:prefLabel "active status" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/burrow-active-status.ttl"^^xsd:anyURI ;
 .
 


### PR DESCRIPTION
suggest merging 'burrow active status', 'warren active status' and 'den active status' into single concept 'active status'. definition changed to accomodate merge