### PR TITLE
Update tree-trunk-type.ttl

### DIFF
--- a/vocab_files/observable_property_concepts/tree-trunk-type.ttl
+++ b/vocab_files/observable_property_concepts/tree-trunk-type.ttl
@@ -6,10 +6,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/3da2a8ca-c0a3-4761-8736-507255eeee68>
     a skos:Concept ;
-    dcterms:source "Ecological Field Monitoring protocols - Basal Area Module, draft v0.1, 30/11/2021" ;
+    dcterms:source "Laws M, McCallum K, Bignall J, Kilpatrick E, O’Neill S, Sparrow B. (2023) Basal Area Module. In ‘Ecological Field Monitoring Protocols Manual using the Ecological Monitoring System Australia’, Version 1. (Eds S O’Neill, K Irvine, A Tokmakoff, B Sparrow). TERN, Adelaide." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "Tree trunk type is a characteristic of the trunk bark displayed by an individual tree - trunk types can be either normal, ellipse, buttressed or multi-stemmed for example." ;
-    skos:prefLabel "tree trunk type" ;
+    skos:definition "Problem trees are trees with diameter at breast height (DBH) at 1.3 m is not easily measured or not representative when taken at 1.3 m. Problem tree types include ellipse, buttressed, deformed or multi-stemmed trees." ;
+    skos:prefLabel "problem tree type" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/tree-trunk-type.ttl"^^xsd:anyURI ;
 .
 


### PR DESCRIPTION
- suggest changing this label to 'problem tree type' as this is the most accurate description for the listed options for this concept. 
- updated the definition as bark does not determine tree trunk type.
- source updated to V1 protocols