### PR TITLE
Update stem-cracks-presence.ttl

### DIFF
--- a/vocab_files/observable_property_concepts/stem-cracks-presence.ttl
+++ b/vocab_files/observable_property_concepts/stem-cracks-presence.ttl
@@ -8,8 +8,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     dcterms:source "McCallum K, Potter T, Cox, B, Laws M, Bignall J, O’Neill S, Sparrow B. (2023) Condition Module. In ‘Ecological Field Monitoring Protocols Manual using the Ecological Monitoring System Australia’. (Eds S O’Neill, K Irvine, A Tokmakoff, B Sparrow). TERN, Adelaide." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "Indicates any evidence of the presence of cracks on the stem." ;
-    skos:prefLabel "stem cracks presence" ;
+    skos:definition "Indicates any presence of cracks or crevices on the trunk of a tree." ;
+    skos:prefLabel "Trunk crack presence" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/stem-cracks-presence.ttl"^^xsd:anyURI ;
 .
 


### PR DESCRIPTION
Suggest changing the concept label from 'stem cracks presence to ' trunk crack presence' as this better represents the data being collected (the presence of cracks in a tree trunk greater than 2 m tall and with a diameter greater than 10 cm - stem is not the correct word to define this) definition updated to reflect the label change