### PR TITLE
Update tree-hollow-position.ttl

### DIFF
--- a/vocab_files/observable_property_concepts/tree-hollow-position.ttl
+++ b/vocab_files/observable_property_concepts/tree-hollow-position.ttl
@@ -8,8 +8,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     dcterms:source "McCallum K, Potter T, Cox, B, Laws M, Bignall J, O’Neill S, Sparrow B. (2023) Condition Module. In ‘Ecological Field Monitoring Protocols Manual using the Ecological Monitoring System Australia’. (Eds S O’Neill, K Irvine, A Tokmakoff, B Sparrow). TERN, Adelaide." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "Refers to the position of the relative position of the hollow in a tree, i.e., upper parts of the main branch or lower parts, etc." ;
-    skos:prefLabel "tree hollow position" ;
+    skos:definition "Refers to the height of a hollow in a tree. A tree hollow is a natural depression or hole formed within the branch or trunk of a tree, where fauna takes refuge." ;
+    skos:prefLabel "tree hollow height" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/tree-hollow-position.ttl"^^xsd:anyURI ;
 .
 


### PR DESCRIPTION
Suggest changing the concept label from "tree hollow position' to 'tree hollow height' as this has changed in the app to be a numerical value not a categorical field.  Definition has been updated to match the label change