### PR TITLE
Update soil-mottle-abundance.ttl

### DIFF
--- a/vocab_files/observable_property_concepts/soil-mottle-abundance.ttl
+++ b/vocab_files/observable_property_concepts/soil-mottle-abundance.ttl
@@ -6,9 +6,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/049cd754-cdc4-46e3-868f-fefa258522c9>
     a skos:Concept ;
-    dcterms:source "Ecological Field Monitoring protocols - Soil module , draft v0.1, 30/11/2021" ;
+    dcterms:source "http://anzsoil.org/def/au/asls/soil-profile/Mottle-abundance" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "Mottles are spots, blotches or streaks of subdominant colours different form the matrix colour and different from the colour of the ped surface. The percentage is estimated by eye using the chart in Figure 11 p 141 (R.C. McDonald, R.F. Isbell and J.G. Speight (2009) Land Surface) for comparison" ;
+    skos:definition "Mottles are spots, blotches or streaks of subdominant colours different form the matrix colour and different from the colour of the ped surface. The percentage is estimated by eye using the chart in yellowbook for comparison." ;
     skos:exactMatch <http://linked.data.gov.au/def/tern-cv/8e2ee0f0-c6a7-4b8b-a05d-d7d3dae8c580> ;
     skos:prefLabel "soil mottle abundance" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/soil-mottle-abundance.ttl"^^xsd:anyURI ;


### PR DESCRIPTION
updated definition to omit yellowbook page number reference as it will be outdated with the release of v4 updated source to yellowbook vocab