### PR TITLE
Update soil-mottle-contrast.ttl

### DIFF
--- a/vocab_files/observable_property_concepts/soil-mottle-contrast.ttl
+++ b/vocab_files/observable_property_concepts/soil-mottle-contrast.ttl
@@ -10,7 +10,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 Monitoring Protocols Manual: Standardising environmental monitoring and data systems for improved decision
 making. Draft v 0.1 Report to DCCEEW. TERN, Adelaide.""" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "Soil mottle contrast are categorical descriptions of mottles contrasts with codes in the YB pages 159–161 (The National Committee on Soil and Terrain 2009)." ;
+    skos:definition "Categorical descriptions of mottle contrasts" ;
     skos:prefLabel "soil mottle contrast" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/soil-mottle-contrast.ttl"^^xsd:anyURI ;
 .


### PR DESCRIPTION
updated definition to exclude yellow book page reference as the new version will outdate the definition