### PR TITLE
Update soil-mottle-type.ttl

### DIFF
--- a/vocab_files/observable_property_concepts/soil-mottle-type.ttl
+++ b/vocab_files/observable_property_concepts/soil-mottle-type.ttl
@@ -6,11 +6,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/79df1f41-1a8e-44af-8362-87ac7944cfc3>
     a skos:Concept ;
-    dcterms:source """Laws M, McCallum K, Bignall J, O’Neill S, Sparrow B. (unpublished draft) ‘soil plot description module’ in ….. (eds) Ecological Field
-Monitoring Protocols Manual: Standardising environmental monitoring and data systems for improved decision
-making. Draft v 0.1 Report to DCCEEW. TERN, Adelaide.""" ;
+    dcterms:source "Steen C, Laws M, Finn L, Gellie N, O’Neill S, Sparrow B. (2023) Soil Module. In ‘Ecological Field Monitoring Protocols Manual using the Ecological Monitoring System Australia’. (Eds S O’Neill, K Irvine, A Tokmakoff, B Sparrow). TERN, Adelaide; http://anzsoil.org/def/au/asls/soil-profile/Mottle-type" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "Soil mottle types are categorical descriptions of mottles and its associations with codes in the YB pages 159–161 (The National Committee on Soil and Terrain 2009)." ;
+    skos:definition "Soil mottle types are categorical descriptions of mottles and its associations" ;
     skos:prefLabel "soil mottle type" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_property_concepts/soil-mottle-type.ttl"^^xsd:anyURI ;
 .


### PR DESCRIPTION
definition updated to omit yellowbook page reference as it will be outdated with the publication of v4

updated reference to v1 of the protocol, and yellowbook vocabs