### PR TITLE
Update aspect.ttl

### DIFF
--- a/vocab_files/attribute_concepts/aspect.ttl
+++ b/vocab_files/attribute_concepts/aspect.ttl
@@ -9,9 +9,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     dcterms:source "Ecological Field Monitoring protocols - Camera traps module , draft v0.1, 30/11/2021" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:definition "Horizontal direction to which a mountain slope faces. Degrees from North. N=360, no slope=0." ;
+    skos:definition "The proportional relationship between an image's width and height." ;
     skos:exactMatch <http://linked.data.gov.au/def/tern-cv/0a92253d-a07b-4762-b653-4c363650cb44> ;
-    skos:prefLabel "aspect" ;
+    skos:prefLabel "aspect ratio" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/aspect.ttl"^^xsd:anyURI ;
     tern:valueType tern:Float ;
 .


### PR DESCRIPTION
Suggest splitting the concept 'aspect' into two separate concepts. Aspect and aspect ratio.

'Aspect' has the definition 'Identifies the downslope direction (orientation) of the slope. the reading is taken looking down the slope. Due north is recorded as 360 degrees. Aspect can only have a value of 1 to 360 degrees a value of 0 indicates that there is no slope.' Refers to landform and direction

'Aspect ratio' definition 'The proportional relationship between an image's width and height.' Refers to settings in a camera