### PR TITLE
Updated the feature type of OP `homogeneity measure` in `Plot description` to `plant community`

### DIFF
--- a/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/homogeneity-measure.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/homogeneity-measure.ttl
@@ -7,7 +7,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/bb9c7cc0-f3c0-4671-b2d9-f7e8e859917c>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/homogeneity-measure.ttl"^^xsd:anyURI ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/84f645c7-9094-40e5-977c-82da64aeb85e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/88068941-4dc9-4b44-bcfe-5eeeb3ba1a21> ;

--- a/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/homogeneity-measure.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/homogeneity-measure.ttl
@@ -7,7 +7,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/6ac9a6e3-88ca-46fc-8bdd-f33491fd2acf>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/homogeneity-measure.ttl"^^xsd:anyURI ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/cdd61f02-261e-48c0-a4af-046c22bc8202> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/615edd85-ea58-4d3c-b737-d31d8447ad49> ;


### PR DESCRIPTION
This PR updated the feature type of OP `homogeneity measure` in `plot description` module to `plant community`, was `plant occurrence`. 

Reason provided by @arunherb :

> It refers to a different vegetation community from the one being sampled.
> For example, if the sampling vegetation is "eucalypt woodland' and the other vegetation is an 'Acacia woodland' it is a community level feature of interest.
> It is a group of plants at a given location-  especially those found in a particular area or habitat.