### PR TITLE
In `Plot description`, for OPs `aspect`, `slope`, `homogeneity measure`, `cover`, added their unit of measurement and values range in metadata

### DIFF
--- a/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/aspect.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/aspect.ttl
@@ -1,5 +1,6 @@
 PREFIX schema: <https://schema.org/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX unit: <http://qudt.org/vocab/unit/>
 PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -8,9 +9,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/aspect.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8282fb22-4135-415c-8ca2-317860d102fb> ;
+    urnp:maxInclusive 360 ;
+    urnp:minExclusive 0 ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/84f645c7-9094-40e5-977c-82da64aeb85e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/88068941-4dc9-4b44-bcfe-5eeeb3ba1a21> ;
+    urnp:unitOfMeasurement unit:DEG ;
     urnp:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/cover.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/cover.ttl
@@ -1,5 +1,6 @@
 PREFIX schema: <https://schema.org/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX unit: <http://qudt.org/vocab/unit/>
 PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -8,9 +9,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/cover.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/32834f36-a478-45be-97f4-ff2ff51e9f5c> ;
+    urnp:maxInclusive 100 ;
+    urnp:minInclusive 0 ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/84f645c7-9094-40e5-977c-82da64aeb85e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/60c714fa-4e8d-454d-b4cd-7fe77da7f47e> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/88068941-4dc9-4b44-bcfe-5eeeb3ba1a21> ;
+    urnp:unitOfMeasurement unit:PERCENT ;
     urnp:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/homogeneity-measure.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/homogeneity-measure.ttl
@@ -1,5 +1,6 @@
 PREFIX schema: <https://schema.org/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX unit: <http://qudt.org/vocab/unit/>
 PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -8,9 +9,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/homogeneity-measure.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:minInclusive 0 ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/84f645c7-9094-40e5-977c-82da64aeb85e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/88068941-4dc9-4b44-bcfe-5eeeb3ba1a21> ;
+    urnp:unitOfMeasurement unit:M ;
     urnp:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/slope.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/slope.ttl
@@ -1,5 +1,6 @@
 PREFIX schema: <https://schema.org/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX unit: <http://qudt.org/vocab/unit/>
 PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -8,9 +9,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/plot-description-enhanced-protocol/slope.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8282fb22-4135-415c-8ca2-317860d102fb> ;
+    urnp:maxInclusive 90 ;
+    urnp:minInclusive 0 ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/84f645c7-9094-40e5-977c-82da64aeb85e> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/88068941-4dc9-4b44-bcfe-5eeeb3ba1a21> ;
+    urnp:unitOfMeasurement unit:DEG ;
     urnp:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/aspect.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/aspect.ttl
@@ -1,5 +1,6 @@
 PREFIX schema: <https://schema.org/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX unit: <http://qudt.org/vocab/unit/>
 PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -8,9 +9,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/aspect.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8282fb22-4135-415c-8ca2-317860d102fb> ;
+    urnp:maxInclusive 360 ;
+    urnp:minExclusive 0 ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/cdd61f02-261e-48c0-a4af-046c22bc8202> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/0e0423c6-0dc3-40aa-9776-410a94299256> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/615edd85-ea58-4d3c-b737-d31d8447ad49> ;
+    urnp:unitOfMeasurement unit:DEG ;
     urnp:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/cover.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/cover.ttl
@@ -1,5 +1,6 @@
 PREFIX schema: <https://schema.org/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX unit: <http://qudt.org/vocab/unit/>
 PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -8,9 +9,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/cover.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/32834f36-a478-45be-97f4-ff2ff51e9f5c> ;
+    urnp:maxInclusive 100 ;
+    urnp:minInclusive 0 ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/cdd61f02-261e-48c0-a4af-046c22bc8202> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/60c714fa-4e8d-454d-b4cd-7fe77da7f47e> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/615edd85-ea58-4d3c-b737-d31d8447ad49> ;
+    urnp:unitOfMeasurement unit:PERCENT ;
     urnp:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/homogeneity-measure.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/homogeneity-measure.ttl
@@ -1,5 +1,6 @@
 PREFIX schema: <https://schema.org/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX unit: <http://qudt.org/vocab/unit/>
 PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -8,9 +9,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/homogeneity-measure.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ea3a4c64-dac3-4660-809a-8ad5ced8997b> ;
+    urnp:minInclusive 0 ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/cdd61f02-261e-48c0-a4af-046c22bc8202> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/325d5ff2-8c81-484a-a422-c13ff29666a9> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/615edd85-ea58-4d3c-b737-d31d8447ad49> ;
+    urnp:unitOfMeasurement unit:M ;
     urnp:valueType tern:Float ;
 .
 

--- a/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/slope.ttl
+++ b/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/slope.ttl
@@ -1,5 +1,6 @@
 PREFIX schema: <https://schema.org/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX unit: <http://qudt.org/vocab/unit/>
 PREFIX urnc: <urn:class:>
 PREFIX urnp: <urn:property:>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -8,9 +9,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/plot-description/plot-description-standard-protocol/slope.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/8282fb22-4135-415c-8ca2-317860d102fb> ;
+    urnp:maxInclusive 90 ;
+    urnp:minInclusive 0 ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/cdd61f02-261e-48c0-a4af-046c22bc8202> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/b036ba09-d061-4a1c-99a8-890efc462a2c> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/615edd85-ea58-4d3c-b737-d31d8447ad49> ;
+    urnp:unitOfMeasurement unit:DEG ;
     urnp:valueType tern:Float ;
 .
 


### PR DESCRIPTION
This PR added units and values range for some OPs in `Plot description`.

aspect --- qudt unit-DEG --- (0,360]
cover --- qudt unit-PERCENT --- [0,100]
homogeneity measure --- qudt unit-M --- [0,...)
slope --- qudt unit-DEG --- [0,90]