### PR TITLE
Updated the RDF type of `Plot description` method collection to display correctly in RVA

### DIFF
--- a/vocab_files/methods_by_module/plot-description/collection.ttl
+++ b/vocab_files/methods_by_module/plot-description/collection.ttl
@@ -8,8 +8,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/1ff9e97c-3bdd-44c9-bdd3-401fa31c0b32>
     a
-        skos:Concept ,
-        tern:Method ;
+        skos:Collection ,
+        skos:OrderedCollection ,
+        tern:MethodCollection ;
     dcterms:description """<h3>Contents</h3>
   <ol>
   <li><a href="#module-overview">Module Overview</a></li>


### PR DESCRIPTION
This PR updated the RDF type of `Plot description` method collection to `skos:Collection`, `skos:OrderedCollection`, `tern:MethodCollection` to fix the display error in RVA.