### PR TITLE
Fixed RDF types in methods vocabularies & Fixed the web page URL on RVA

### DIFF
--- a/src/dawe_nrm/api/rva/__init__.py
+++ b/src/dawe_nrm/api/rva/__init__.py
@@ -128,7 +128,7 @@ def publish_new_vocabulary_version(
             },
             {
                 "ap-web-page": {
-                    "url": "https://linkeddata.tern.org.au/viewers/dawe-vocabs"
+                    "url": "https://linkeddata.tern.org.au/prez/dawe-cv/v/"
                 },
                 "source": "user",
                 "discriminator": "webPage",

--- a/vocab_files/methods_by_module/intervention/collection.ttl
+++ b/vocab_files/methods_by_module/intervention/collection.ttl
@@ -8,9 +8,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/8b334ccd-5e1a-474c-88e1-0f9b02d7d9c6>
     a
-        skos:Collection ,
-        skos:OrderedCollection ,
-        tern:MethodCollection ;
+        skos:Concept ,
+        tern:Method ;
     dcterms:description """<h3>Contents</h3>
 <ol><li><a href="#module-overview">Module overview</a></li>
   <li><a href="#introduction-and-background">Introduction and Background</a></li>

--- a/vocab_files/methods_by_module/plot-selection-and-layout/collection.ttl
+++ b/vocab_files/methods_by_module/plot-selection-and-layout/collection.ttl
@@ -8,8 +8,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/d15d05db-5007-411e-b257-105ef4f76821>
     a
-        skos:Concept ,
-        tern:Method ;
+        skos:Collection ,
+        skos:OrderedCollection ,
+        tern:MethodCollection ;
     dcterms:description """
     <h3>Contents</h3>
   <ol>


### PR DESCRIPTION
This PR fixed wrong RDF types in methods vocabularies and updated the web page URL on RVA because we updated the vocab viewer to prez.