### PR TITLE
Updated CVs for version-2

### DIFF
--- a/vocab_files/attribute_concepts/data-licensing-comments.ttl
+++ b/vocab_files/attribute_concepts/data-licensing-comments.ttl
@@ -1,0 +1,17 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<https://linked.data.gov.au/def/nrm/b50985d7-df52-4fe2-b205-c1511a94c17f>
+    a skos:Concept ;
+    dcterms:source "O'Neill S, Laws M, Kilpatrick E, Singh Ramesh A, McCallum K, Sparrow B. (2024) Targeted Surveys Module. In 'Ecological Field Monitoring Protocols Manual using the Ecological Monitoring System Australia'. (Eds S O'Neill, K Irvine, A Tokmakoff, B Sparrow). TERN, Adelaide." ;
+    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
+    skos:definition "Refers to any key information relating to the data licensing arrangements (e.g. public domain, attribution, attribution-share alike, restricted, delayed release, confidential, etc.)." ;
+    skos:prefLabel "data licensing comments" ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/data-licensing-comments.ttl"^^xsd:anyURI ;
+    tern:valueType tern:Text ;
+.
+

--- a/vocab_files/attribute_concepts/dataset-title.ttl
+++ b/vocab_files/attribute_concepts/dataset-title.ttl
@@ -1,0 +1,18 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<https://linked.data.gov.au/def/nrm/ea7bef3a-e733-4ce7-a25f-f19b0feb9183>
+    a skos:Concept ;
+    dcterms:description "This is a concise title name which covers the where, what, how, when of the dataset. For example, Golden Ray Reserve, WA, Annual Vegetation Condition Monitoring Surveys, 2019–2022. " ;
+    dcterms:source "O'Neill S, Laws M, Kilpatrick E, Singh Ramesh A, McCallum K, Sparrow B. (2024) Targeted Surveys Module. In 'Ecological Field Monitoring Protocols Manual using the Ecological Monitoring System Australia'. (Eds S O'Neill, K Irvine, A Tokmakoff, B Sparrow). TERN, Adelaide." ;
+    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
+    skos:definition "The title of the Targeted Survey Monitoring dataset/s that serves as a data identifier for submission." ;
+    skos:prefLabel "dataset title" ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/dataset-title.ttl"^^xsd:anyURI ;
+    tern:valueType tern:Text ;
+.
+

--- a/vocab_files/attribute_concepts/linked-dataset.ttl
+++ b/vocab_files/attribute_concepts/linked-dataset.ttl
@@ -1,0 +1,19 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<https://linked.data.gov.au/def/nrm/ea7bef3a-e733-4ce7-a25f-f19b0feb9183>
+    a skos:Concept ;
+    dcterms:description "This should include the names of any linked or related datasets from the monitoring program that have been submitted via Monitor App previously." ;
+    dcterms:source "O'Neill S, Laws M, Kilpatrick E, Singh Ramesh A, McCallum K, Sparrow B. (2024) Targeted Surveys Module. In 'Ecological Field Monitoring Protocols Manual using the Ecological Monitoring System Australia'. (Eds S O'Neill, K Irvine, A Tokmakoff, B Sparrow). TERN, Adelaide." ;
+    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
+    skos:altLabel "related dataset" ;
+    skos:definition "The dataset/s that are linked or related or associated with any previous Targeted Survey dataset/s." ;
+    skos:prefLabel "linked dataset" ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/dataset-title.ttl"^^xsd:anyURI ;
+    tern:valueType tern:Text ;
+.
+


### PR DESCRIPTION
 Added CV 'dataset title', 'data licensing comments'  and 'linked datast' as attributes in Targeted Survey Module version-2