### PR TITLE
Standardized names for most LUTs - second round cleaning

### DIFF
--- a/vocab_files/categorical_collections/luts/camera-trap-points.ttl
+++ b/vocab_files/categorical_collections/luts/camera-trap-points.ttl
@@ -46,7 +46,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:CategoricalConceptMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/camera-trap-points.ttl"^^xsd:anyURI ;
     urnp:categoricalCollection <https://linked.data.gov.au/def/nrm/2742ccd6-cbe7-406c-a4aa-265944774454> ;
-    urnp:categoricalConcept <https://linked.data.gov.au/def/nrm/0cad1fc8-0741-5dc8-90f5-7a4c6c7fba5f> ;
+    urnp:categoricalConcept <https://linked.data.gov.au/def/nrm/256e08e4-98e9-496b-aa20-f4676c1b5595> ;
     urnp:conceptDefinition "The spatial point location, denoting the 'east' end or the orientation of the study plot, e.g. in a basal sweep sampling point, camera trap point, coarse woody debris transect, etc." ;
     urnp:conceptSource "https://core.vocabs.paratoo.tern.org.au/api/lut-camera-trap-points"^^xsd:anyURI ;
 .
@@ -58,7 +58,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:member
         <https://linked.data.gov.au/def/nrm/0b63439c-837a-51c4-817e-9196a95e4e20> ,
-        <https://linked.data.gov.au/def/nrm/0cad1fc8-0741-5dc8-90f5-7a4c6c7fba5f> ,
+        <https://linked.data.gov.au/def/nrm/256e08e4-98e9-496b-aa20-f4676c1b5595> ,
         <https://linked.data.gov.au/def/nrm/852808d1-baaf-5ce1-985d-ba197ae5e513> ,
         <https://linked.data.gov.au/def/nrm/96e94d59-32db-5ea0-b409-dcef6568a873> ,
         <https://linked.data.gov.au/def/nrm/df58bcc5-34d9-5020-a519-bc83b18824db> ;

--- a/vocab_files/categorical_collections/luts/categorical_concepts.ttl
+++ b/vocab_files/categorical_collections/luts/categorical_concepts.ttl
@@ -1,3 +1,4 @@
+PREFIX dwc: <http://rs.tdwg.org/dwc/terms/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
@@ -7,14 +8,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/002eced4-6c27-5da8-9a44-9ddf679daeb1>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- ID" ;
+    skos:prefLabel "taxon code - ID" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/0041ab4c-a277-5070-ad93-27decb1f7edc>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Time lapse" ;
+    skos:prefLabel "time lapse" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -29,7 +30,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/004e6871-7ea1-41fc-a083-e92bc806eaf3>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - Plant" ;
+    skos:prefLabel "observation method tier 3 - plant" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -64,7 +65,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/01260f56-9beb-5b18-8af8-96fd476cdb97>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Live tree" ;
+    skos:prefLabel "microhabitat - live tree" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -156,14 +157,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/02ea9cd4-b649-5040-bd98-bc406c8e297a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Grass" ;
+    skos:prefLabel "microhabitat - grass" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/03169edb-713d-5b4c-a9c1-06ab8a8ec58c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Vegetated Waterway (Bioswale)" ;
+    skos:prefLabel "vegetated waterway (bioswale)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -205,14 +206,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/039c4521-c2c6-4d57-8e6b-8c7dfcb6e16a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Knife (e.g. for opening galls)" ;
+    skos:prefLabel "knife (e.g. for opening galls)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/03adee6e-0548-4a78-9691-70ff9cb32d35>
     a skos:Concept ;
+    dwc:scientificName "Rusa unicolor" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:altLabel "Rusa unicolor" ;
     skos:prefLabel "sambar deer" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
@@ -220,14 +221,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/03ee0064-f289-52ae-91a8-ed0aace9a1f2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Cave" ;
+    skos:prefLabel "cave" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/03fe8f0c-5be2-40cd-b75e-6f366bde449a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - Fresh" ;
+    skos:prefLabel "observation method tier 3 - fresh" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -327,7 +328,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/05254074-af21-56bd-8681-f2dd0cca667f>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "pan structure- Massive" ;
+    skos:prefLabel "pan structure - massive" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -348,7 +349,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/056e4b3a-d26a-5061-8bcd-3d25f2cfb2f3>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Moderate scalding (5-50%)" ;
+    skos:prefLabel "moderate scalding (5-50%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -363,7 +364,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "WS" ;
-    skos:prefLabel "scats (within)" ;
+    skos:prefLabel "within scat" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -383,15 +384,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/05c18e55-7eda-5bcd-8099-5c32fc3d449d>
     a skos:Concept ;
+    dwc:scientificName "Oryctolagus cuniculus" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Rabbit (Oryctolagus cuniculus)" ;
+    skos:prefLabel "Rabbit" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/05ffeed3-fd7b-5ec8-864f-6a6632502373>
     a skos:Concept ;
+    dwc:scientificName "Vulpes vulpes" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Fox (Vulpes vulpes)" ;
+    skos:prefLabel "Fox" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -426,7 +429,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/0665f9b4-88b3-5665-843f-6b463debfe20>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IM" ;
+    skos:prefLabel "taxon code - IM" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -482,7 +485,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/074d030b-631f-55e8-9005-cd08537855dd>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "cover class- bc" ;
+    skos:prefLabel "cover class - bc" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -517,7 +520,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/079a0393-3fa3-5595-a06f-4fcf13e547f0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Canopy" ;
+    skos:prefLabel "microhabitat - canopy" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -545,35 +548,35 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/08745403-0d44-5e04-81fd-efed7fea5ec3>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Single grain" ;
+    skos:prefLabel "single grain" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/088c63bd-a49a-5d68-bd21-f10686278cc6>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Ash (sandy)" ;
+    skos:prefLabel "ash (sandy)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/08a8e1ea-15e0-5f14-a95d-0af1b53f647b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- AAR" ;
+    skos:prefLabel "taxon code - AAR" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/08e3ba0e-6ef8-59b3-87c5-7943f9895820>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Cobbly or cobbles (60-200 mm)" ;
+    skos:prefLabel "cobbly or cobbles (60-200 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/08ed411e-70a0-5bcb-8d48-08f68882f405>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- AR" ;
+    skos:prefLabel "taxon code - AR" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -587,21 +590,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/08f21bd5-b4f1-5cc1-9c16-50e7b1676f5b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Bare" ;
+    skos:prefLabel "bare" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/090f1d05-690d-5844-8e7b-fec1d5704287>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Partially Degenerated (estimated 2-7 days)" ;
+    skos:prefLabel "partially degenerated (estimated 2-7 days)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/095f9659-43f0-5b5e-a7f7-8f955e3aa5d9>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- B1" ;
+    skos:prefLabel "soil horizon - B1" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -636,7 +639,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/09b57b74-ee2d-5270-8e32-4368989eac08>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Coastal Waters" ;
+    skos:prefLabel "coastal waters" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -672,7 +675,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/09f62da8-090b-5e67-bd52-15883926866e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Other Earthworks" ;
+    skos:prefLabel "other earthworks" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -718,17 +721,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
-<https://linked.data.gov.au/def/nrm/0ae90953-9c95-54d7-985c-036c6134502a>
-    a skos:Concept ;
-    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Pig" ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
-.
-
 <https://linked.data.gov.au/def/nrm/0af978b5-1416-5ccc-863f-e97aed200ba0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Rubbish" ;
+    skos:prefLabel "microhabitat - rubbish" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -757,7 +753,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/0b63439c-837a-51c4-817e-9196a95e4e20>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "camera trap point- West" ;
+    skos:notation "W" ;
+    skos:prefLabel "camera trap point - West" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -771,14 +768,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/0b7fe004-dd5c-57d0-a51e-3f49002db918>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "helicopter door- removed" ;
+    skos:prefLabel "helicopter door removed" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/0bbf3247-35a7-5c02-87d7-ff859fb17689>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Around" ;
+    skos:prefLabel "microhabitat - around" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -829,21 +826,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "E" ;
-    skos:prefLabel "East" ;
+    skos:prefLabel "basal sweep sampling point - East" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/0caef692-3e06-53c3-b9cd-38485c643865>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "surface strew- None apparent" ;
+    skos:prefLabel "surface strew - none apparent" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/0ce0cabf-e499-5360-82f4-67866d9f60da>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Immature (sub-adult)" ;
+    skos:prefLabel "immature (sub-adult)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -857,7 +854,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/0cf3678c-7e8e-59bd-a390-0e180b892423>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Camera Trapping" ;
+    skos:prefLabel "camera trapping" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -872,7 +869,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/0d1361f7-f475-5eed-87e9-ff365efc1f61>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Ground" ;
+    skos:prefLabel "microhabitat - ground" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -921,7 +918,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/0e123d10-50ca-59df-b4f5-c3a0a05bee89>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Above" ;
+    skos:prefLabel "microhabitat - above" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -977,14 +974,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/0edb44c6-71fe-5591-a0cc-0092ba4cacaa>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Regurgitant" ;
+    skos:prefLabel "regurgitant" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/0ee7e5d2-6fe9-5ed8-90ed-22fa37acb872>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Very coarse (20-60 mm)" ;
+    skos:prefLabel "very coarse (20-60 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1012,7 +1009,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/0ef9141a-26e9-5bb1-b227-0adc149485f3>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Garbic" ;
+    skos:prefLabel "garbic" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1033,14 +1030,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/0f60d198-4d2f-54fb-be71-342551f0433f>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Field observer" ;
+    skos:prefLabel "field observer" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/0fc1f1d2-a9c0-51a1-a26f-0bc7af65e708>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Bouldery or boulders (600-2000 mm)" ;
+    skos:prefLabel "bouldery or boulders (600-2000 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1054,7 +1051,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/0fcfe04c-45e7-5d82-9577-350078e2f8ca>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- At" ;
+    skos:prefLabel "microhabitat - at" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1124,7 +1121,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/116b965d-329b-50e2-8fd9-1acceaebc95e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- MPR" ;
+    skos:prefLabel "taxon code - MPR" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1159,14 +1156,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/120367b8-78a1-514d-9805-f751a6163273>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil substrate- Water" ;
+    skos:prefLabel "soil substrate - water" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/1208831d-e64f-5543-a28c-99693b0d7643>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Terraced land (alluvial)" ;
+    skos:prefLabel "terraced land (alluvial)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1187,7 +1184,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/127ce77c-9dd5-5b29-a4e3-37946fb4b469>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "structure size- 2-5 mm" ;
+    skos:prefLabel "structure size - 2-5 mm" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1209,7 +1206,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/130cad8e-0a82-515a-ad75-6b84d165db6c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Solution doline" ;
+    skos:prefLabel "solution doline" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1237,21 +1234,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/13575533-bf21-538e-a39f-8d0bf52eccc6>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Unidentified" ;
+    skos:prefLabel "unidentified" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/1379a843-eadf-48fe-ad4e-f16e793468f2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - Water" ;
+    skos:prefLabel "observation method tier 3 - water" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/13a86a5f-9181-57f2-8633-86eeda01ae42>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Liquid nitrogen (N2)" ;
+    skos:prefLabel "Liquid nitrogen" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1293,7 +1290,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/145e80b2-8d8f-5db1-8d9a-7bf934e1ec77>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Low (30-90m)" ;
+    skos:prefLabel "low (30-90m)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1394,7 +1391,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/15a6d32a-a62d-5508-b79c-18983719274e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- II" ;
+    skos:prefLabel "taxon code - II" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1531,7 +1528,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/1805654a-b336-537e-a0af-41ad40edf397>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- MDP" ;
+    skos:prefLabel "taxon code - MDP" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1546,7 +1543,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "NE" ;
-    skos:prefLabel "compass direction - North East" ;
+    skos:prefLabel "North East" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1560,7 +1557,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/18811849-a39f-5fb0-8f94-031d7f2c2b31>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Cliff" ;
+    skos:prefLabel "microhabitat - cliff" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1701,19 +1698,20 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/19db6460-805b-581e-8567-d5d9e7cb2347>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Water sample (eDNA)" ;
+    skos:prefLabel "water sample - eDNA" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/19f2a736-5d2c-51ce-8200-c3f5240f3a2a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Scat and Other Traces" ;
+    skos:prefLabel "scat and other traces" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/19f2da82-66a4-5b46-96b1-4dc2e2b0c9e1>
     a skos:Concept ;
+    dwc:genus "Cervus" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:prefLabel "deer" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
@@ -1821,14 +1819,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/1b0dc27f-55d3-5ad6-a134-2afbf5b42af4>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Gravid (carrying eggs or young)" ;
+    skos:prefLabel "gravid (carrying eggs or young)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/1b1a0c2e-70a2-5aad-954e-52eab30320c5>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Medium gravelly or medium pebbles (6-20 mm)" ;
+    skos:prefLabel "medium gravelly or medium pebbles (6-20 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1942,7 +1940,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/1c28294c-7c33-5962-baae-8aaafcc5a46a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Olfactory" ;
+    skos:prefLabel "olfactory" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -1970,7 +1968,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/1cbff1d1-4c44-5638-b8d9-4dd4269182ee>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "asc class- Red" ;
+    skos:prefLabel "asc class - Red" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2055,14 +2053,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/1df397c4-9970-52a3-9998-d5b17e13c0c8>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil strength- Strong" ;
+    skos:prefLabel "soil strength - strong" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/1e09068d-53c6-59c2-9c9f-2896a1e9fdd2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "mottle abundance- Few (2-10%)" ;
+    skos:prefLabel "mottle abundance - few (2-10%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2147,7 +2145,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/1f00c682-7ef5-5576-9727-3bcaebe52355>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Celsius" ;
+    skos:prefLabel "celsius" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2167,8 +2165,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/1f180410-e77a-47ff-975c-e0d3ffcb7863>
     a skos:Concept ;
+    dwc:scientificName "Canis lupus dingo" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "dingo - Canis lupus dingo" ;
+    skos:prefLabel "dingo" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2196,7 +2195,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/1fc7edc1-8d57-568f-9a98-9ab9ddcf2816>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Linear or longitudinal (seif) dune" ;
+    skos:prefLabel "linear or longitudinal (seif) dune" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2218,7 +2217,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2021899a-913c-59bd-8593-acf82cdd4915>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Habitat Augmentation" ;
+    skos:prefLabel "habitat augmentation" ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/955aac04-bdfc-531d-8a09-6896d1f745bf> ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
@@ -2249,7 +2248,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/20ab3724-e0dc-5259-83e4-3f5f161a14d5>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- AAM" ;
+    skos:prefLabel "taxon code - AAM" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2355,14 +2354,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2250e3dc-4165-5d6a-81f9-95b413ca45b9>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Dermosolic" ;
+    skos:prefLabel "dermosolic" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/22572d25-d436-56f9-a2fa-aaea32e98f4a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "asc class- Yellow" ;
+    skos:prefLabel "asc class - yellow" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2383,7 +2382,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/22e7b53b-dab7-5bb5-a693-ceac461a2503>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Upper canopy" ;
+    skos:prefLabel "microhabitat - upper canopy" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2411,7 +2410,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2323acca-3250-5bad-8fae-0c500516aa1b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IE" ;
+    skos:prefLabel "taxon code - IE" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2432,7 +2431,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2364339f-cd61-515c-b9e7-16fe98f76853>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Discontinuous" ;
+    skos:prefLabel "discontinuous" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2454,7 +2453,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/23c9dfb7-537f-5abe-a731-05ee886f6431>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Ash (fine)" ;
+    skos:prefLabel "ash (fine)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2483,14 +2482,22 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/25470550-c03d-5937-b678-6e3a90fe86cd>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- C" ;
+    skos:prefLabel "soil horizon - C" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/255b6ddb-80ed-5cbb-8bcb-edfc6daa5f9c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IT" ;
+    skos:prefLabel "taxon code - IT" ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
+.
+
+<https://linked.data.gov.au/def/nrm/256e08e4-98e9-496b-aa20-f4676c1b5595>
+    a skos:Concept ;
+    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
+    skos:notation "E" ;
+    skos:prefLabel "camera trap point - East" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2511,7 +2518,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/25bd9b72-cf7b-50be-8c60-7cfe2e31a742>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Plantation" ;
+    skos:prefLabel "microhabitat - plantation" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2547,21 +2554,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/263f8259-dbb0-5b95-96d4-6247e42ca11a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Melanic-Sodic" ;
+    skos:prefLabel "melanic-sodic" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/266e7b5a-2559-57fd-9c5c-9b7dbe750861>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Medium (5-10 mm)" ;
+    skos:prefLabel "medium (5-10 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/2686a071-9e7c-5e8a-9136-17c07a1c155a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Mellic" ;
+    skos:prefLabel "mellic" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2575,7 +2582,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/26ae44c1-3cf0-5756-bc50-3b6e5baeb9e0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "void cracks- Fine (<5 mm)" ;
+    skos:prefLabel "void cracks - fine (<5 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2645,7 +2652,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/28189ee4-0eac-5491-82fb-8d127590f75e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- MM" ;
+    skos:prefLabel "taxon code - MM" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2694,14 +2701,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/288788e1-201a-5ab7-a0a8-b4a5e33a3136>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Very steep (56-100%)" ;
+    skos:prefLabel "very steep (56-100%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/2893793e-8c89-5672-8ab8-d553e7e66a15>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "camera trap feature- palatable point" ;
+    skos:prefLabel "camera trap feature - palatable point" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2785,7 +2792,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/29ffe860-8cab-5fa0-a202-5c4c3abc8eb7>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IPH" ;
+    skos:prefLabel "taxon code - IPH" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2799,7 +2806,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2a2b885f-af86-5b29-b8d2-3fab7652eedf>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- HPR" ;
+    skos:prefLabel "taxon code - HPR" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2820,7 +2827,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2a6fcdaf-8034-51bb-82f4-b333e488f0f0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Reeds" ;
+    skos:prefLabel "microhabitat - reeds" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -2870,14 +2877,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2b145527-2fda-5970-bddf-3f65219f537c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Hills" ;
+    skos:prefLabel "hills" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/2b188163-74ed-5047-91f9-857e004b125c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "segregations abundance- Many (20-50%)" ;
+    skos:prefLabel "segregations abundance - many (20-50%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3077,14 +3084,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2dabafda-4237-5f31-ad9d-1f40aa9bb7fe>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IZ" ;
+    skos:prefLabel "taxon code - IZ" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/2dcca73e-5397-5581-8262-9c841a3d74c9>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "200 - 500" ;
+    skos:prefLabel "aerial experience hours - 200-500 h" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3134,7 +3141,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2df499b5-e3e2-5c25-844e-380972fce7a8>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- B2" ;
+    skos:prefLabel "soil horizon - B2" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3183,7 +3190,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2e79ab2b-8862-554a-8163-3aaa58b3c7e8>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Long dead (>4 weeks)" ;
+    skos:prefLabel "long dead (>4 weeks)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3235,14 +3242,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2f05f0a2-972b-5cb2-95c8-3a5183c13be5>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Consolidated rock (unidentified)" ;
+    skos:prefLabel "consolidated rock (unidentified)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/2f24fcd0-f533-5368-a3bb-6a44e4a4c4dc>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Folic" ;
+    skos:prefLabel "folic" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3271,28 +3278,28 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2f778ac8-49d6-42ff-8693-f9c1cb64d29b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Wire saw" ;
+    skos:prefLabel "wire saw" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/2f8188d1-3b51-5c04-8a6b-9f3b80a2a4d1>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Minor scalding (<5%)" ;
+    skos:prefLabel "minor scalding (<5%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/2f8e8209-f9b0-59eb-9b7d-cf23e91fcd93>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "cover class- i" ;
+    skos:prefLabel "cover class - i" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/2f99c46f-2be8-5c1c-8505-94af76ba96bc>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Extremely coarse (>50mm)" ;
+    skos:prefLabel "extremely coarse (>50mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3328,7 +3335,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/2fed0ca5-d57f-5268-80bd-f301904a76b0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Aspirator" ;
+    skos:prefLabel "aspirator" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3484,14 +3491,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/329d8b4e-fb69-5786-af63-8fc92ec018f7>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Vineland" ;
+    skos:prefLabel "vineland" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/32b3cc3b-5350-5c77-9eec-e4c461192cea>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Aluminous (aluminium)" ;
+    skos:prefLabel "aluminous (chiefly containing aluminium)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3513,7 +3520,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/32f28e75-d0a0-5e62-832b-640994d8a846>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "transect acesss- driven" ;
+    skos:prefLabel "transect acesss - driven" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3626,7 +3633,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3502b86c-6d7c-5e8e-a01e-14f0c9080899>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IH" ;
+    skos:prefLabel "taxon code - IH" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3655,7 +3662,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3567f2f8-eb2d-5f68-ad6a-95b80259d284>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "confidence level- 3" ;
+    skos:prefLabel "confidence level - 3" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3725,7 +3732,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3629a6a6-8e4a-5117-8065-4d2562b8a903>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IEP" ;
+    skos:prefLabel "taxon code - IEP" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3760,7 +3767,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/36cac678-b741-5649-8ab7-b2a0d11168b3>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Terrace (alluvial)" ;
+    skos:prefLabel "terrace (alluvial-based)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -3944,7 +3951,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3976da63-e79e-5c1d-988e-4635dd87f38a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Over" ;
+    skos:prefLabel "microhabitat - over" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4007,7 +4014,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3a1e4a07-df4a-5a18-9f61-72f7c87306f5>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Isolated rushes" ;
+    skos:prefLabel "isolated rushes" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4035,8 +4042,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/3a86540a-7f40-578a-8431-6bcacb0194d7>
     a skos:Concept ;
+    dwc:scientificName "Felis catus" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Cat (Felis catus)" ;
+    skos:prefLabel "Cat" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4071,14 +4079,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3acad728-0515-5ca1-9abf-121f2b93ac11>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Rock Community" ;
+    skos:prefLabel "microhabitat - rock Community" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/3accad8e-d088-5e9b-b13b-7fb4941f129a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Power line" ;
+    skos:prefLabel "microhabitat - power line" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4100,7 +4108,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "AH" ;
-    skos:prefLabel "aerial observation (helicopter)" ;
+    skos:prefLabel "aerial observation - helicopter" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4164,14 +4172,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3c0c31d0-7360-55cd-bd02-5e2a2e47b11b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Sparse rushland" ;
+    skos:prefLabel "sparse rushland" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/3c29feed-c081-5852-b4a1-cf6b90002088>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "mottle abundance- Very few (<2%)" ;
+    skos:prefLabel "mottle abundance - very few (<2%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4192,7 +4200,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3c53b668-6ab3-57e1-8eac-ccf3440743c6>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- AOP" ;
+    skos:prefLabel "taxon code - AOP" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4350,14 +4358,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3e35fe6f-0a8e-5c6a-8508-a6902af4bc5b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IL" ;
+    skos:prefLabel "taxon code - IL" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/3e49a58e-6616-5262-a1fb-79e5f507bb06>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "50 - 200" ;
+    skos:prefLabel "aerial experience hours - 50-200h" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4392,21 +4400,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3eb35504-17b5-5a3a-a317-41822227ae4f>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "confidence level- 2" ;
+    skos:prefLabel "confidence level - 2" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/3eb7fb66-1b5b-5b46-9c5e-7c0272e8042e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Med" ;
+    skos:prefLabel "med" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/3ebe19a4-b9e7-5752-9a0d-ec208266e34b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "segregation size- Fine (<2 mm)" ;
+    skos:prefLabel "segregation size - fine (<2 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4442,7 +4450,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3ef6dd43-f79d-5b4c-8980-d325d4612885>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "helicopter door- in-situ" ;
+    skos:prefLabel "helicopter door in-situ" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4456,7 +4464,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3efad441-5b2e-54ec-9fec-943ed95baafb>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "camera trap feature- trail" ;
+    skos:prefLabel "camera trap feature - trail" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4484,7 +4492,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/3f26c2b2-4b1a-5f7e-9bfa-c46f2c0d7b42>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Foliage" ;
+    skos:prefLabel "microhabitat - Foliage" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4669,7 +4677,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/41753bc6-4123-58d2-b687-448fe192863f>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IMG" ;
+    skos:prefLabel "taxon code - IMG" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4719,7 +4727,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/41e9f83d-305b-590d-bdfb-79c50b3dcfc9>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Artificial surface" ;
+    skos:prefLabel "microhabitat - artificial surface" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4762,7 +4770,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/429d415e-ce1b-5dff-a541-1e9153ac3ced>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Abrupt (5-20 mm)" ;
+    skos:prefLabel "abrupt (5-20 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4861,7 +4869,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/4410ac55-ba9f-5436-8fc7-9c2d5f924d2c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Coarse (10-20 mm)" ;
+    skos:prefLabel "coarse (10-20 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -4896,7 +4904,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/4471b20b-b5dc-5b9a-b379-c8c5c0f340d6>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- A1" ;
+    skos:prefLabel "soil horizon - A1" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5015,7 +5023,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/458da0b8-031b-510a-acb7-e2eec0ebfd32>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IP" ;
+    skos:prefLabel "taxon code - IP" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5106,7 +5114,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/470a2818-0f60-5684-819e-86c23a781df9>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Orchard" ;
+    skos:prefLabel "microhabitat - orchard" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5120,7 +5128,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/4749bf65-92c4-5a4c-927e-47c6dfbcfd26>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "mottle abundance- Many (20-50%)" ;
+    skos:prefLabel "mottle abundance - many (20-50%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5212,7 +5220,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/48144b0b-e89a-5859-a700-93fe98cf91ba>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Park" ;
+    skos:prefLabel "microhabitat - park" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5234,21 +5242,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "WP" ;
-    skos:prefLabel "pellet (within)" ;
+    skos:prefLabel "within pellet" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/48e1fafa-70c2-5512-ac91-06f07cd3a133>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IG" ;
+    skos:prefLabel "taxon code - IG" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/48fcbe24-9626-5712-a00b-6e4ec8f92dce>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Steep (32-56%)" ;
+    skos:prefLabel "steep (32-56%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5311,14 +5319,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/49778dd7-2312-5038-a80e-c5ad5f73d73b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Coarse (15-30 mm)" ;
+    skos:prefLabel "coarse (15-30 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/49afe82d-45d9-54e3-bea9-e11ff4d18313>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "mottle size- Fine (<5mm)" ;
+    skos:prefLabel "mottle size - fine (<5mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5438,7 +5446,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/4b41b775-6f3c-58b2-b4ba-b025aa69c465>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Camera Trap" ;
+    skos:prefLabel "camera trap" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5482,7 +5490,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/4bbda02a-9013-5ce8-b36e-8a12031add1a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Soil" ;
+    skos:prefLabel "microhabitat - soil" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5503,7 +5511,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/4c0617b0-729d-5906-aa95-d2a8330587bd>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "20 - 50" ;
+    skos:prefLabel "aerial experience hours - 20-50h" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5517,14 +5525,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/4c33fb42-105b-57ab-9445-38deff1c7e34>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Dead shrub" ;
+    skos:prefLabel "microhabitat - dead shrub" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/4c385849-82eb-501d-ad4b-f61c74ffa3b9>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Ferromanganiferous (iron-manganese)" ;
+    skos:prefLabel "Ferromanganiferous (chiefly of iron-manganese alloy)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5538,7 +5546,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/4c71d7a4-0f28-53a1-814b-6174b759f844>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Within" ;
+    skos:prefLabel "microhabitat - within" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5552,7 +5560,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/4c89ea8d-be37-5021-b472-e886e85dad86>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "horizon suffix- (?)" ;
+    skos:prefLabel "horizon suffix - '?'" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5815,7 +5823,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/5011c8b4-824b-5585-bd30-44fc4ca4fae2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Organic (humified; well-decomposed organic matter)" ;
+    skos:prefLabel "organic (humified, well-decomposed organic matter)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5829,7 +5837,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/50708dcf-27c0-5e4b-b99c-d707efc03f2a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Soil sample (eDNA)" ;
+    skos:prefLabel "soil sample - eDNA" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5865,7 +5873,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "SEE" ;
-    skos:prefLabel "plant phenological stage - seedling" ;
+    skos:prefLabel "phenological stage - seedling" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5893,7 +5901,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/5132d186-21fc-5c40-a5b1-b4ba25285dd8>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- MCH" ;
+    skos:prefLabel "taxon code - MCH" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5914,7 +5922,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/5184be74-be36-51d7-9df8-be136c7dc668>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel ">1000" ;
+    skos:prefLabel "aerial experience hours - >1000h" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -5994,7 +6002,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/52b42cd1-9f1e-56a2-8f19-b52513806db5>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Under" ;
+    skos:prefLabel "microhabitat - under" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6015,7 +6023,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/53691227-fec8-5518-9278-ac3e10a587a6>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Fresh (estimate <24 hours)" ;
+    skos:prefLabel "fresh (estimate <24 hours)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6150,7 +6158,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/54b194e4-6ddb-506e-b6c4-69c653ffeb16>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- P1" ;
+    skos:prefLabel "soil horizon - P1" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6172,7 +6180,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/54e540de-abed-5a83-a9e6-e68bc9c93499>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Alcrete (bauxite)" ;
+    skos:prefLabel "alcrete (bauxite)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6201,14 +6209,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/5519bb5f-e42b-5cb1-87f3-378e168d86d2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Trunk" ;
+    skos:prefLabel "microhabitat - tree trunk" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/558b878c-bbab-4e61-8607-2f376558b203>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Light (specify type)" ;
+    skos:prefLabel "light source (specific type)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6271,7 +6279,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/565511a8-c50b-53fb-8f59-995e52a01ed2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Other (specify)" ;
+    skos:prefLabel "other (specify)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6379,17 +6387,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
-<https://linked.data.gov.au/def/nrm/57629205-2427-5988-9920-9605574847a2>
-    a skos:Concept ;
-    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Camel" ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
-.
-
 <https://linked.data.gov.au/def/nrm/57a167b9-537b-5b43-95c6-951a530301ec>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Rock" ;
+    skos:prefLabel "microhabitat - rock" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6417,7 +6418,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/57f4b6c9-20ad-521b-a556-dc538ac6b41e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- A3" ;
+    skos:prefLabel "soil horizon - A3" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6453,7 +6454,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/5866a53f-5c43-59ab-a1b5-8d2770a4e3d7>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Bombs (volcanic)" ;
+    skos:prefLabel "bombs (of volcanic origin)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6480,8 +6481,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/58993c3a-9237-5112-aec9-0e6bf776b242>
     a skos:Concept ;
+    dwc:scientificName "Sus scrofa" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Pig (Sus scrofa)" ;
+    skos:prefLabel "Pig" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6503,7 +6505,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/58c84a83-61dd-4b15-a687-52cfb5d39e4f>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - Old" ;
+    skos:prefLabel "observation method tier 3 - old" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6573,7 +6575,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/59d93466-20ae-569f-843b-b650c1fa107e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Metamorphic rock (unidentified)" ;
+    skos:prefLabel "metamorphic rock (unidentified)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6601,14 +6603,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/5a5b27be-ff82-5ab0-8a83-9cea61ad1dae>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "No scalding" ;
+    skos:prefLabel "no scalding" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/5a900149-23c7-4e39-b542-fdbb5dbfb8ea>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - Invertebrate derived" ;
+    skos:prefLabel "observation method tier 3 - invertebrate derived" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6650,14 +6652,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/5b1e7e84-5a23-5444-91c1-f97a872bc38e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Lagoon" ;
+    skos:prefLabel "lagoon" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/5b38b1ec-de00-51cc-a081-63f438ddf67f>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Extremely low ( <9m)" ;
+    skos:prefLabel "extremely low (<9m)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6839,7 +6841,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/5de8089e-23b5-5914-ba5d-e623af0679a2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Amongst" ;
+    skos:prefLabel "microhabitat - amongst" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6916,7 +6918,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/5eba3fe8-5f65-57cc-ba1e-8714c2dd91da>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Rockland (>50% bedrock exposed)" ;
+    skos:prefLabel "rockland (>50% bedrock exposed)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -6974,21 +6976,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/5fc3bd77-3c7f-54b2-8bcd-2a01c2412bb0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Sparse heathland" ;
+    skos:prefLabel "sparse heathland" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/60289f83-a0a9-50d9-bf9c-a0879c08ad55>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Highly calcareous" ;
+    skos:prefLabel "highly calcareous" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/602c9e40-9ff7-5482-b2a3-1c77d82bb7c8>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Site Preparation" ;
+    skos:prefLabel "site preparation" ;
     sosa:usedProcedure <https://linked.data.gov.au/def/nrm/222129f5-3045-56dd-9643-a84ab4758672> ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
@@ -7004,7 +7006,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/603ae65a-4a7c-5d95-9daf-9d324275e3a7>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- HDL" ;
+    skos:prefLabel "taxon code - HDL" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7040,7 +7042,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/60a769a3-b575-550b-8b6c-ed1325d5a969>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "tree trunk- Smooth" ;
+    skos:prefLabel "tree trunk - smooth" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7048,14 +7050,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "N" ;
-    skos:prefLabel "compass direction - North" ;
+    skos:prefLabel "North" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/60add443-4b6c-5527-b9f8-c2a5459e1960>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- A" ;
+    skos:prefLabel "soil horizon - A" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7183,7 +7185,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/628f3139-4bfc-51d1-ac7d-791c78892d5f>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "cover class- c" ;
+    skos:prefLabel "cover class - c" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7261,7 +7263,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/635aa2f9-38ea-5ae5-a132-4540fef55f6c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IDI" ;
+    skos:prefLabel "taxon code - IDI" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7310,7 +7312,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/64243bdc-e212-5a32-801c-a84d2bc83a2a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Earthy (dominantly non-clayey)" ;
+    skos:prefLabel "earthy (dominantly non-clayey)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7331,14 +7333,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/645bd97b-96f1-5803-963e-73d146cd4718>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Extremely coarse (>60mm)" ;
+    skos:prefLabel "extremely coarse (>60mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/64646801-af41-538b-a5fa-b72a1f0ca02b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Slightly rocky (2-10% bedrock exposed)" ;
+    skos:prefLabel "slightly rocky (2-10% bedrock exposed)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7359,7 +7361,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/64b85224-ebbe-546d-8e21-82afd51bffdb>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Dry ice (solid CO2)" ;
+    skos:prefLabel "dry ice (solid carbon dioxide)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7380,7 +7382,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/64e1189b-d0cc-5d9e-a5d7-424a58a9a83a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Visually identified in the field (sighting)" ;
+    skos:prefLabel "visually identified in the field (sighting)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7401,7 +7403,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/6516e6a3-b830-5197-bf94-9f18fd3e529f>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Low shrub" ;
+    skos:prefLabel "microhabitat - low shrub" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7492,7 +7494,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/65f4fafb-2255-5026-ab8d-56c3d5fa3edb>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Large Boulders (>2000 mm)" ;
+    skos:prefLabel "large Boulders (>2000 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7607,7 +7609,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/67dd3f1a-c40a-539e-bcc0-7295a9883f4d>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Moderately inclined (10-32%)" ;
+    skos:prefLabel "moderately inclined (10-32%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7698,8 +7700,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/69369a4b-1608-58c9-b37c-00758d401bf4>
     a skos:Concept ;
+    dwc:scientificName "Canis lupus familiaris" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:altLabel "Canis lupus familiaris" ;
     skos:prefLabel "dog" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
@@ -7714,7 +7716,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/698613dc-feb6-54c4-8743-31fb3eb72100>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Roost" ;
+    skos:prefLabel "microhabitat - roost" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7834,14 +7836,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/6b06eeec-04d8-5f67-9353-c8ae3d837dcb>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Water" ;
+    skos:prefLabel "microhabitat - water" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/6b082dd5-98c8-5aaf-ab78-ec89b47a31c0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "mottle abundance- Common (10-20%)" ;
+    skos:prefLabel "mottle abundance - common (10-20%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7905,7 +7907,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/6c512b04-413f-5f45-87ff-8e9886a9d315>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Crown" ;
+    skos:prefLabel "microhabitat - crown" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -7946,8 +7948,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/6d0b66b3-16f6-552a-b38f-88dc9bbf7abc>
     a skos:Concept ;
+    dwc:scientificName "Dama dama" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:altLabel "Dama dama" ;
     skos:prefLabel "fallow deer" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
@@ -7955,14 +7957,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/6d121507-aa79-5141-bf49-a87ab3616b2d>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Precipitous (>100%)" ;
+    skos:prefLabel "precipitous (>100%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/6d2bf662-c186-5fcc-b3b3-30f6ca941976>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Fence" ;
+    skos:prefLabel "microhabitat - Fence" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8068,7 +8070,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/6eb699aa-8426-5966-a4e0-1f421eff8c14>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "medium macropore abundance- Many" ;
+    skos:prefLabel "medium macropore abundance- many" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8104,7 +8106,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/6efb9a27-961a-54ce-a466-167cfefb2379>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Aurally identified based on collected evidence (call recording)" ;
+    skos:prefLabel "aurally identified based on collected evidence (call recording)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8146,14 +8148,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/6fb7d262-c3d5-5b65-baf0-3fd82fa924a7>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Urban" ;
+    skos:prefLabel "urban" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/6fc46b99-2d15-59e3-b171-76350ec1fea7>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Other pans" ;
+    skos:prefLabel "other pans" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8231,7 +8233,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/70a28e99-9b14-5f88-bddb-3dc8fd8f9901>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Live mallee" ;
+    skos:prefLabel "microhabitat - live mallee" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8326,7 +8328,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:altLabel "complete carcass" ;
     skos:notation "CF" ;
-    skos:prefLabel "animal carcass (whole)" ;
+    skos:prefLabel "whole animal carcass" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8406,7 +8408,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/72f4bfe3-430a-564c-b41f-2c8e01bcb14a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- HCO" ;
+    skos:prefLabel "taxon code - HCO" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8441,7 +8443,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/7348607d-d17f-5d9f-8a87-3a90c91968e4>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Argillaceous (clayey)" ;
+    skos:prefLabel "argillaceous (clayey)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8455,7 +8457,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/73a29e6a-f17c-5df3-a0c6-837de0e1c80c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Very strong rock (>200 MPa)" ;
+    skos:prefLabel "very strong rock (>200 MPa)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8469,7 +8471,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/73e3624e-7012-5bce-8567-326397fefbee>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Bare ground" ;
+    skos:prefLabel "microhabitat - bare ground" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8532,21 +8534,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/751819a4-ae29-5eca-bfda-5ae854518c00>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Grassland" ;
+    skos:prefLabel "microhabitat - grassland" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/756b33c0-d851-56fa-b2b6-3ec1ebf7daf0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Rocky outcrop" ;
+    skos:prefLabel "microhabitat - rocky outcrop" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/7597dd8c-650b-57a5-a308-678624880951>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- ASO" ;
+    skos:prefLabel "taxon code - ASO" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8560,7 +8562,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/76006889-a6d2-5a8e-97fb-861bcb64005e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "fine macropore abundance- Few" ;
+    skos:prefLabel "fine macropore abundance - few" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8588,7 +8590,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/766cae76-a628-5faf-961b-dca1369cd8bf>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IO" ;
+    skos:prefLabel "taxon code - IO" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8609,14 +8611,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/76a354e9-b79b-51db-8eca-4df06af103cb>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Ferruginous-organic (iron-organic matter)" ;
+    skos:prefLabel "ferruginous-organic (chiefly iron-organic matter)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/76a620a2-a46b-59a5-80ad-bbe7984a9ed8>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Gradual (50-100mm)" ;
+    skos:prefLabel "gradual (50-100mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8630,7 +8632,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/76f2d8fa-29d1-552f-ae7d-41ee5963cf47>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Expert (museum/herbarium)" ;
+    skos:prefLabel "expert (museum/herbarium)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8644,7 +8646,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/77340b00-a26d-5c9a-aa05-4cb962ed64ad>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Drainage line" ;
+    skos:prefLabel "microhabitat - Drainage line" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8686,7 +8688,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/7829c93e-d5c5-59b4-abc8-3d3d62cc03f7>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Fresh (estimate 24 hours - <48 hours)" ;
+    skos:prefLabel "fresh (estimate 24 hours - <48 hours)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8728,7 +8730,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/789d858a-c7f3-59ac-81af-8423e6f59e01>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Gypseous (gypsum)" ;
+    skos:prefLabel "gypseous (of gypsum origin)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8764,7 +8766,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/79699d93-59d2-5d54-945d-6463ffbe4418>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- In" ;
+    skos:prefLabel "microhabitat - in" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8799,7 +8801,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/7a02f61b-b7e6-5573-8167-8cf5ac0d66fe>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Very high (>300 m)" ;
+    skos:prefLabel "very high (>300 m)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8848,14 +8850,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/7af6b4ff-45f3-5ded-9ebe-36817f60541c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Frozen (domestic freezer -20°C)" ;
+    skos:prefLabel "frozen (domestic freezer -20°C)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/7b2cd090-83ab-5dc8-8d3d-0e521c3915ea>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- O2" ;
+    skos:prefLabel "soil horizon - O2" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -8911,7 +8913,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/7baff134-8833-5e8f-a957-754730945b7d>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- C" ;
+    skos:prefLabel "taxon code - C" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9018,7 +9020,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/7d235739-f863-527f-b8cf-6d605c9779f1>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Tree hollow" ;
+    skos:prefLabel "microhabitat - tree hollow" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9032,7 +9034,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/7d8c9d50-5f96-5cf4-8791-f01cb5b0d553>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- B3" ;
+    skos:prefLabel "soil horizon - B3" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9166,7 +9168,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/7f320607-9a8f-5d59-96ee-a54f465cbafc>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IS" ;
+    skos:prefLabel "taxon code - IS" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9180,7 +9182,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/7f73f520-17cb-530a-a072-7bdcaaf4f0f3>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Sand" ;
+    skos:prefLabel "microhabitat - sand" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9203,13 +9205,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:prefLabel "Spotter - naked eye" ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
-.
-
-<https://linked.data.gov.au/def/nrm/801ee910-8d5c-5829-b20c-08ab22b35b9e>
-    a skos:Concept ;
-    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Fox" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9309,7 +9304,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/81f11aec-77c6-5737-8fa7-7691ad8100fe>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "segregation abundance- Few (2-10%)" ;
+    skos:prefLabel "segregation abundance - few (2-10%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9352,7 +9347,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "MVS 46" ;
-    skos:prefLabel "Sea, estuaries (includes seagrass)" ;
+    skos:prefLabel "sea, estuaries (includes seagrass)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9388,7 +9383,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/82de4b41-e4d3-5680-ac48-72c195f4eba4>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "cover class- r" ;
+    skos:prefLabel "cover class - r" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9417,7 +9412,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/8315301f-668f-57c3-9c9b-cdec7ebb6e60>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IPL" ;
+    skos:prefLabel "taxon code - IPL" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9431,7 +9426,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/831c12f7-0d6a-5b7b-9fe2-206de18b78fe>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "mature fruit (fresh)" ;
+    skos:prefLabel "fresh mature fruit" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9445,14 +9440,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/838ad921-8017-5a27-9256-3f5234a0424c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Seed Nursery" ;
+    skos:prefLabel "seed nursery" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/838bb2eb-5344-5a01-af94-59be8bf8a54e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Weak rock (25-50 MPa)" ;
+    skos:prefLabel "weak rock (25-50 MPa)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9551,7 +9546,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/84cad8b2-45c5-5af0-bdae-8ef96d0adc7b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "No rock outcrop (no bedrock exposed)" ;
+    skos:prefLabel "no rock outcrop (no bedrock exposed)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9593,7 +9588,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/852808d1-baaf-5ce1-985d-ba197ae5e513>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "camera trap point- North" ;
+    skos:notation "N" ;
+    skos:prefLabel "camera trap point - North" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9614,7 +9610,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/85b66cd6-ced2-5176-8338-6cf889145d08>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Cone (volcanic)" ;
+    skos:prefLabel "cone (volcanic)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9714,7 +9710,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/876b96eb-eb75-5a14-9d78-8d74cecb5576>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- P2" ;
+    skos:prefLabel "soil horizon - P2" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9777,7 +9773,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/88851ebc-0fee-5787-a23d-e8067aecc3ce>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Dead mallee" ;
+    skos:prefLabel "microhabitat - Dead mallee" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9791,21 +9787,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/88a95847-a81b-579b-b9e7-1457c9e96897>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Hypersulfidic" ;
+    skos:prefLabel "hypersulfidic" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/88e7fd67-581e-5fe6-a4b3-c5eb1e8a352e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Aurally identified in the field (call)" ;
+    skos:prefLabel "aurally identified in the field (call)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/892d1436-8bc8-5ad8-b4e4-d1b3e90b9f27>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Forest" ;
+    skos:prefLabel "microhabitat - Forest" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9847,7 +9843,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/89a31040-6702-5381-b9bf-5452694293c0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Severe scalding (>50%)" ;
+    skos:prefLabel "severe scalding (>50%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9904,7 +9900,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/8a17328c-dc90-51fd-bd7b-d4e933af15f6>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Strong rock (100-200 MPa)" ;
+    skos:prefLabel "strong rock (100-200 MPa)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -9946,7 +9942,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/8aa61e8e-94ac-4a5a-9cc0-151ae3baa77e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - With egg/s" ;
+    skos:prefLabel "observation method tier 3 - with egg/s" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -10024,7 +10020,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/8bd7eeea-f869-5e29-81a9-79ee7d8c7cb1>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Ridge" ;
+    skos:prefLabel "microhabitat - ridge" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -10224,7 +10220,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/8e888553-695c-5c96-94df-7c6e44b0c4ec>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Very many (>50%)" ;
+    skos:prefLabel "very many (>50%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -10296,7 +10292,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/90490694-8f1b-5969-a280-9c94b2d73320>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- D" ;
+    skos:prefLabel "soil horizon - D" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -10324,28 +10320,28 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/90e130f5-a89c-5627-99dc-18b82b3c93e9>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Other cutans" ;
+    skos:prefLabel "other cutans" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/90e7bd85-69b8-5e8c-b2fa-00d2fbc2f050>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "5 - 10" ;
+    skos:prefLabel "aerial experience hours - 5-10h" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/90f0d19c-0cc5-5fa4-97d2-4e88f60f21fc>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- AAC" ;
+    skos:prefLabel "taxon code - AAC" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/9144bc37-88a2-5551-8087-dbebd939b49a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Degenerated (estimate 2 - 4 weeks)" ;
+    skos:prefLabel "degenerated (estimate 2 - 4 weeks)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -10387,7 +10383,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/91fbc097-c683-5f34-929b-3dc3f8b6ffd4>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "very or abundant (50 - 90%)" ;
+    skos:prefLabel "very or abundant (50-90%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -10415,7 +10411,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/9292d220-67c5-533b-9dda-b79c336c4fe1>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Bridge" ;
+    skos:prefLabel "microhabitat - bridge" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -10507,7 +10503,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/9430fb9f-e9e0-5c2b-950c-e525fedb6908>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "blood (whole)" ;
+    skos:prefLabel "whole blood" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -10543,7 +10539,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "SW" ;
-    skos:prefLabel "compass direction - South West" ;
+    skos:prefLabel "South West" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -10698,7 +10694,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/96e94d59-32db-5ea0-b409-dcef6568a873>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "trap point- South" ;
+    skos:notation "S" ;
+    skos:prefLabel "camera trap point - South" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -10943,14 +10940,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/99b370dc-ddf1-5915-96e3-2e2c6f5125e3>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Ground cover" ;
+    skos:prefLabel "microhabitat - ground cover" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/99cd3423-e492-592a-8edb-d0d265320bd9>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Mallee" ;
+    skos:prefLabel "microhabitat - mallee" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -10970,8 +10967,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/9a292b27-007c-5e1a-a7e2-d8536ea56c2b>
     a skos:Concept ;
+    dwc:scientificName "Camelus dromedaries" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Camel (Camelus dromedaries)" ;
+    skos:prefLabel "Camel" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -10986,7 +10984,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "FLO" ;
-    skos:prefLabel "plant life stage/phenological stage - flowers" ;
+    skos:prefLabel "phenological stage - flowers" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11000,7 +10998,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/9a7c0772-85f7-5f0b-8e6d-73b312137261>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Pan Trap" ;
+    skos:prefLabel "pan trap" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11035,7 +11033,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/9b0e0fbb-b83c-5f82-a95c-8dbc3e8f259c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "fine macropore abundance- Many" ;
+    skos:prefLabel "fine macropore abundance - many" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11056,7 +11054,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/9b2e1206-5f3f-5fe6-9dd0-1915432dd9e6>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Humic/Humosesquic" ;
+    skos:prefLabel "humic/humosesquic" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11141,7 +11139,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/9c81067e-0a4d-53dc-9cb3-09e349c4c583>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Positive Competition" ;
+    skos:prefLabel "positive competition" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11156,14 +11154,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/9caf5893-d507-5942-92d5-4baa54bdf5db>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Mistletoe" ;
+    skos:prefLabel "mistletoe" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/9cd0a002-60e4-51a1-adcc-2de54706c4f4>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Pebble (5-50 mm)" ;
+    skos:prefLabel "pebble (5-50 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11192,7 +11190,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/9d35d131-5302-56ae-a2f8-baaa7dc635d3>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "pan trap colour- Yellow" ;
+    skos:prefLabel "pan trap colour - yellow" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11220,7 +11218,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/9d996f9e-a272-5eb9-a2a3-2b1de6042ad6>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "High (90-300 m)" ;
+    skos:prefLabel "high (90-300 m)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11320,7 +11318,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "NW" ;
-    skos:prefLabel "compass direction - North West" ;
+    skos:prefLabel "North West" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11355,7 +11353,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/9f7f3c92-9ab0-5c0b-9aa5-cdd99db55812>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Ruins" ;
+    skos:prefLabel "microhabitat - ruins" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11369,7 +11367,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/9f9e4f03-1ed8-55f5-a6e2-c65bef12cdd6>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- ASZ" ;
+    skos:prefLabel "taxon code - ASZ" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11397,7 +11395,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/9fb2e458-13bc-5067-84af-fe0eb7d55a58>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- MSY" ;
+    skos:prefLabel "taxon code - MSY" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11419,7 +11417,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a018ca68-7d19-5319-b9a4-d41b0e2de428>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Nest" ;
+    skos:prefLabel "microhabitat - nest" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11476,7 +11474,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a0eae0de-1bb3-4694-aff2-c06f5de3966a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Soapy water (default)" ;
+    skos:prefLabel "soapy water (default)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11519,14 +11517,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a193a17f-e8d6-552e-bb2b-241c32ff2d20>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Trap and Cull" ;
+    skos:prefLabel "trap and cull" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/a19a72a0-2433-5fd2-8f64-16503637b9ee>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Hummocky (weakly oriented dune)" ;
+    skos:prefLabel "hummocky (weakly oriented dune)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11540,7 +11538,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a1ce2a5b-3208-59e0-a55d-686baa84bfa0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Below" ;
+    skos:prefLabel "microhabitat - below" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11596,7 +11594,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a33ba5a1-d6d4-51d5-aa0d-6fd7a7188102>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Cave" ;
+    skos:prefLabel "microhabitat - cave" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11681,7 +11679,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a4681534-22bb-5f52-917e-9c1700ac632b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Tree bark" ;
+    skos:prefLabel "microhabitat - tree bark" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11703,7 +11701,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a496cbfb-7c2e-4a71-bb03-7cac9f9aa150>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - With chick/s" ;
+    skos:prefLabel "observation method tier 3 - with chick/s" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11724,7 +11722,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a4db485d-1e36-5a99-b3eb-77c8ab8d7c0c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Dead tree" ;
+    skos:prefLabel "microhabitat - Dead tree" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11759,21 +11757,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a524dcf0-1731-55b1-a9cc-d772ad0eb42e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Sulfurous (sulfur)" ;
+    skos:prefLabel "sulfurous (sulfur-based)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/a5310bb2-c66d-4bbf-ab85-111b54c540ab>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - Subfossil" ;
+    skos:prefLabel "observation method tier 3 - subfossil" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/a537f9e2-cdd2-5490-be12-7cef432bdafc>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- A2" ;
+    skos:prefLabel "soil horizon - A2" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11858,7 +11856,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "WG" ;
-    skos:prefLabel "animal gut (within)" ;
+    skos:prefLabel "within animal gut" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11886,7 +11884,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a6a3565b-2452-54c1-85c3-382a8d6fc659>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "<5" ;
+    skos:prefLabel "aerial experience hours - <5h" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11959,7 +11957,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a74e073c-0f3f-5f9c-a2e8-ea0903b4cfab>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Sky" ;
+    skos:prefLabel "microhabitat - sky" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -11980,7 +11978,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a768a331-cbec-5013-8450-78c021f2dd84>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "10 - 20" ;
+    skos:prefLabel "aerial experience hours - 10-20h" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12002,7 +12000,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a7c4555f-8308-5ea3-b8f5-56f51c149ea4>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Visually identified in the field (sign)" ;
+    skos:prefLabel "visually identified in the field (sign)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12016,14 +12014,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a80fd3dd-894e-5ad6-a2dc-b7e82e26baa5>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Alluvial plain" ;
+    skos:prefLabel "alluvial plain" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/a825d243-d9b0-5c4b-9b96-95795d6acdc1>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "segregation abundance- Very few (<2%)" ;
+    skos:prefLabel "segregation abundance - very few (<2%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12094,7 +12092,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a96d7507-e823-5f3a-a26b-62313538e0bb>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Other" ;
+    skos:prefLabel "other" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12122,7 +12120,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/a9af3bfe-aff1-5f3a-a88d-d91fc1c57d78>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Detrital sedimentary rock (unidentified)" ;
+    skos:prefLabel "detrital sedimentary rock (unidentified)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12172,7 +12170,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "SEN" ;
-    skos:prefLabel "plant phenological stage - senescent" ;
+    skos:prefLabel "phenological stage - senescent" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12180,7 +12178,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "AF" ;
-    skos:prefLabel "aerial observation (fixed wing aircraft)" ;
+    skos:prefLabel "aerial observation - fixed wing aircraft" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12244,21 +12242,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ab13ed8a-5a93-5ed4-bd6f-d78fa87f669a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "moisture status- Moist" ;
+    skos:prefLabel "moisture status - moist" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ab34c0ec-dd74-5ff0-9736-f9ae0964d3f8>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "medium macropore abundance- Few" ;
+    skos:prefLabel "medium macropore abundance- few" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ab4717cc-8cc8-5fa7-8d5e-e3dc0be746ac>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Visually identified based on collected evidence (voucher specimen)" ;
+    skos:prefLabel "visually identified based on collected evidence (voucher specimen)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12287,7 +12285,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/aba838ec-5721-523d-9fc2-b97e530f5037>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "cover class- d" ;
+    skos:prefLabel "cover class - d" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12336,7 +12334,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ac37dbbc-c655-5dbd-b204-2923f3135e8c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Stony or stones (200-600 mm)" ;
+    skos:prefLabel "stony or stones (200-600 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12385,7 +12383,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/acfa557b-cc6c-52ba-a316-820b6c258009>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Rocky (10-20% bedrock exposed)" ;
+    skos:prefLabel "rocky (10-20% bedrock exposed)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12428,28 +12426,28 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ad3f5eff-1824-58a1-b6cf-c8a34d803096>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Clear" ;
+    skos:prefLabel "clear" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ad4ac640-234b-56b7-874d-a9b2a3a755de>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Visually identified based on collected evidence (video)" ;
+    skos:prefLabel "visually identified based on collected evidence (video)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ad52691c-1b34-56ac-b8eb-f83c72694e96>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Ironstone (where not considered of pedogenic origin)" ;
+    skos:prefLabel "ironstone (where not considered of pedogenic origin)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ad6c3e10-5f84-5305-aa34-1ec45ab4ff88>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Magnetic" ;
+    skos:prefLabel "magnetic" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12485,14 +12483,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/adf897d8-71f1-5322-8886-8cf0ba23a7b1>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Installed" ;
+    skos:prefLabel "installed" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ae03f771-f885-5c43-8892-c0c7814668b4>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "segregations abundance- Common (10-20%)" ;
+    skos:prefLabel "segregations abundance - common (10-20%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12506,7 +12504,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ae4d6ee1-a4a4-58d7-afe3-2232149a96a1>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Igneous rock (unidentified)" ;
+    skos:prefLabel "igneous rock (unidentified)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12522,13 +12520,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:prefLabel "60-80 m" ;
-    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
-.
-
-<https://linked.data.gov.au/def/nrm/aed51aa9-e2f0-571d-b3aa-bebf932fe94f>
-    a skos:Concept ;
-    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Horse" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12549,14 +12540,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/af21777d-d22e-58cc-a645-217333475d32>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Aerial Survey" ;
+    skos:prefLabel "aerial survey" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/af751430-8245-54c7-a0d8-5ed6a16038bb>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Manganiferous (manganese)" ;
+    skos:prefLabel "Manganiferous (manganese-origin)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12585,7 +12576,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/afb7c864-512f-540b-868d-b484a3cdd8cb>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IZY" ;
+    skos:prefLabel "taxon code - IZY" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12629,7 +12620,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/b04ac0f3-f7ee-5ff1-a212-2580f743b181>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Very slightly rocky (<2% bedrock exposed)" ;
+    skos:prefLabel "very slightly rocky (<2% bedrock exposed)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12658,14 +12649,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/b0a10539-838f-59d3-b625-4a099d5d86e0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Beach" ;
+    skos:prefLabel "microhabitat - beach" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/b0c7a591-fb76-5bfd-bbab-f096352cab7c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "extremely or abundant (> 90%)" ;
+    skos:prefLabel "extremely or abundant (>90%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12887,7 +12878,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/b36dc1cf-6b55-55f5-b6ea-727123cd1f75>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- ITR" ;
+    skos:prefLabel "taxon code - ITR" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12908,7 +12899,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/b3b8bc09-fc6a-5098-9bb5-2a2041ed8e15>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IPS" ;
+    skos:prefLabel "taxon code - IPS" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12936,7 +12927,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/b4036db0-9852-5772-bff5-4dffccc829a0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "fauna voucher - Scat" ;
+    skos:prefLabel "scat" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -12956,8 +12947,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/b46bcca8-8c07-5ad3-89e5-d5db8e7bdc3d>
     a skos:Concept ;
+    dwc:scientificName "Axis porcinus" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:altLabel "Axis porcinus" ;
     skos:prefLabel "hog deer" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
@@ -13034,8 +13025,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/b5511180-5573-58fb-970d-cd62447ace2e>
     a skos:Concept ;
+    dwc:scientificName "Cervus elaphus" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:altLabel "Cervus elaphus" ;
     skos:prefLabel "red deer" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
@@ -13100,7 +13091,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/b6d0395d-7972-50bb-a4d0-54d345978a65>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "fine macropore abundance- Common" ;
+    skos:prefLabel "fine macropore abundance - common" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13164,7 +13155,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/b82cfeb6-1194-513a-ba81-5010cb9eb38b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Tidal creek" ;
+    skos:prefLabel "tidal creek" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13179,7 +13170,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/b851a40c-d32b-57a7-8bf8-cca5e202d88d>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "phenological stage - senescent (old) fruit" ;
+    skos:prefLabel "phenological stage - old senescent fruit" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13207,7 +13198,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/b9015147-b6ca-5942-9199-d0d40a78d406>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- O1" ;
+    skos:prefLabel "soil horizon - O1" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13228,7 +13219,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/b9538897-3cca-5f7c-bc66-59c7ffa59d5d>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "medium macropore abundance- Common" ;
+    skos:prefLabel "medium macropore abundance- common" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13249,14 +13240,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/b9dd0a7a-1bca-5ea0-8611-b595d40fcc4b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Resnagging" ;
+    skos:prefLabel "resnagging" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/b9e01bed-982b-5feb-858a-e7d374e6a244>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Coarse gravelly or large pebbles (20-60 mm)" ;
+    skos:prefLabel "coarse gravelly or large pebbles (20-60 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13270,7 +13261,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ba3d5401-184b-5d60-a637-1e3a65dc8099>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Dam" ;
+    skos:prefLabel "microhabitat - Dam" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13348,7 +13339,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/bb4367df-807b-5649-9d13-493969103e2c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- ASC" ;
+    skos:prefLabel "taxon code - ASC" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13418,8 +13409,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/bc1505eb-a36e-5050-a1a4-989479b26d6a>
     a skos:Concept ;
+    dwc:scientificName "Rusa timorensis" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:altLabel "Rusa timorensis" ;
     skos:prefLabel "rusa deer" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
@@ -13448,7 +13439,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/bc6931fc-5ec1-53b0-94f9-d495f4cd24ab>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IME" ;
+    skos:prefLabel "taxon code - IME" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13469,7 +13460,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/bc9a636f-ca3b-59dd-a690-8abc3cefab49>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Partially Degenerated (estimated 1-2 weeks)" ;
+    skos:prefLabel "partially degenerated (estimated 1-2 weeks)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13540,7 +13531,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/bdea8f69-2c3f-593e-a82b-9cb7b39e9531>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IA" ;
+    skos:prefLabel "taxon code - IA" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13618,7 +13609,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/bf782c04-18b7-5fcf-a263-80778af8b55a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Removing Barriers (e.g. Fish Barriers)" ;
+    skos:prefLabel "removing barriers (for e.g., fish barriers)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13688,7 +13679,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/c0473d78-c78d-5482-bff5-3d42053afe1b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "confidence level- 1" ;
+    skos:prefLabel "confidence level - 1" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13716,7 +13707,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/c062840c-1ea3-59cd-82ab-9a6314a67c4d>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Very coarse (20-50 mm)" ;
+    skos:prefLabel "very coarse (20-50 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13751,7 +13742,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/c11c1d38-8f22-5264-a085-ab0a121fe015>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- P" ;
+    skos:prefLabel "soil horizon - P" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13779,21 +13770,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/c19ed739-c24c-5fc6-bf36-397a18bf0c68>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Melanic-Vertic" ;
+    skos:prefLabel "melanic-vertic" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/c1ae9e5f-f1f9-517b-b665-eb6c1b1fa437>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Partially degenerated (estimate 2 - 7 days)" ;
+    skos:prefLabel "partially degenerated (estimate 2-7 days)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/c1c77cbf-4251-5437-b8c8-c3e44304f023>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Tor" ;
+    skos:prefLabel "tor" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13838,7 +13829,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "ST" ;
-    skos:prefLabel "animal tracking (statellite)" ;
+    skos:prefLabel "statellite-based animal tracking" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13866,28 +13857,28 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/c253ea62-a05e-56b6-8712-01c9d443b17a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil drainage- Very poor" ;
+    skos:prefLabel "soil drainage- very poor" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/c262ec0a-b141-5177-8f4c-275cbc0b0e49>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Rear centre" ;
+    skos:prefLabel "rear centre" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/c27d412c-9602-5abc-a950-ad68783e8fab>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Level (<1%)" ;
+    skos:prefLabel "level (<1%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/c31bdf12-5c6b-530a-8c83-0076a02ce5bc>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Very weak rock (1-35 MPa)" ;
+    skos:prefLabel "very weak rock (1-35 MPa)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13959,7 +13950,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "SG" ;
-    skos:prefLabel "scratchings (ground)" ;
+    skos:prefLabel "scratchings - ground" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -13981,7 +13972,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/c48a77ac-18b7-5733-a6e5-ff1d2e5b1733>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Undergrowth" ;
+    skos:prefLabel "microhabitat - undergrowth" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14079,14 +14070,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/c62d2ed8-5634-5c9d-b6a8-4cee434b4994>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Chernic-Leptic" ;
+    skos:prefLabel "chernic-leptic" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/c63f6be5-ae96-52d3-8367-22807218fc1e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Very coarse (>30 mm)" ;
+    skos:prefLabel "very coarse (>30 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14158,14 +14149,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "CP" ;
-    skos:prefLabel "animal carcass (partial)" ;
+    skos:prefLabel "partial animal carcass" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/c83639a5-2b8a-5562-a8e4-fb829d9a240e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- B" ;
+    skos:prefLabel "soil horizon - B" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14187,14 +14178,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/c868dbfb-f6e1-56b3-b7a5-e07d60280df9>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Emaciated" ;
+    skos:prefLabel "emaciated" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/c869555f-9fe9-56c8-ad9f-00717a5c69d3>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Medium (5-15 mm)" ;
+    skos:prefLabel "medium (5-15 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14237,7 +14228,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/c8b5dc15-c1b7-5d23-9a3a-cdc2d7422c5b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Edge of water" ;
+    skos:prefLabel "microhabitat - edge of water" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14245,7 +14236,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "HC" ;
-    skos:prefLabel "animal capture (by hand)" ;
+    skos:prefLabel "hand capture" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14280,7 +14271,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/c94a751a-13d2-5840-b147-928c89ed1d7b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Landform Element- Mound" ;
+    skos:prefLabel "landform element - mound" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14344,14 +14335,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/c9f1f747-3677-5e72-aac0-b49733ea4629>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Cultural Burn" ;
+    skos:prefLabel "cultural burn" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ca2f901c-b284-5d29-8e30-1709da22ba43>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Very low (9-30 m)" ;
+    skos:prefLabel "very low (9-30 m)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14365,14 +14356,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ca963db4-b281-5ae5-a2ce-511dd59ea2a4>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Weirs" ;
+    skos:prefLabel "weirs" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ca9bdb5d-1c8c-538c-ab3f-0604234f3cbe>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Natural Features (Rocks, Logs)" ;
+    skos:prefLabel "natural features (rocks, logs)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14472,14 +14463,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/cbb71575-5e48-5445-ae5e-e2852130bf11>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Grading" ;
+    skos:prefLabel "grading" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/cbbe0bf0-d0c0-5236-973f-fba8e47936c3>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Coarse (6-20 mm)" ;
+    skos:prefLabel "coarse (6-20 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14514,7 +14505,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/cc7bbf39-2616-580b-a9cc-b945b9738d46>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- R" ;
+    skos:prefLabel "soil horizon - R" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14528,7 +14519,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ccc2ab26-b912-50d4-996c-bfd9d0527a98>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Adjacent" ;
+    skos:prefLabel "microhabitat - adjacent" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14592,7 +14583,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/cd4a3d7c-8dcc-513e-b469-15405a290c99>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "camera trap feature- waterpoint" ;
+    skos:prefLabel "camera trap feature - waterpoint" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14671,7 +14662,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/cef047b7-a927-56fc-9489-d5d5ef77b24a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "confidence level- 4" ;
+    skos:prefLabel "confidence level - 4" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14853,7 +14844,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/d110a3b2-a34f-5d94-828d-e539c22ae2b5>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Bank (stream bank)" ;
+    skos:prefLabel "stream bank" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14889,7 +14880,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/d187cbb9-ed3e-54df-9654-814716c15435>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Garden" ;
+    skos:prefLabel "microhabitat - garden" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -14918,7 +14909,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/d1da1e21-c234-5885-8ca3-5dd8969e7989>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Visually identified based on collected evidence (photo)" ;
+    skos:prefLabel "visually identified based on collected evidence (photo)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15011,7 +15002,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/d3d98097-50e2-5ac7-bc80-1769a8cd8bf0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Rocks" ;
+    skos:prefLabel "microhabitat - rocks" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15038,8 +15029,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/d4297430-c86d-58c4-9031-42cbdb50d199>
     a skos:Concept ;
+    dwc:scientificName "Axis axis" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:altLabel "Axis axis" ;
     skos:prefLabel "chital deer" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
@@ -15047,7 +15038,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/d447e447-015f-43f5-afd6-c86d0f5b1ee0>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - Soil" ;
+    skos:prefLabel "observation method tier 3 - soil" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15089,7 +15080,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/d4ccd815-5d81-5842-b059-3a3963b92e2b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Hummock grass" ;
+    skos:prefLabel "microhabitat - hummock grass" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15118,21 +15109,21 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/d54226ec-5267-5a97-bf0b-be216965e218>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "cover class- bi" ;
+    skos:prefLabel "cover class - bi" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/d554d4b1-a716-5d61-a96e-57a95df29050>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Delta" ;
+    skos:prefLabel "delta" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/d579826e-b2f5-59d0-90f9-b044dd3e52ce>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Boulder (250mm +)" ;
+    skos:prefLabel "boulder (250mm +)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15226,7 +15217,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/d6b306ab-56a2-4266-bb35-cdd5332df6f1>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - Active" ;
+    skos:prefLabel "observation method tier 3 - active" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15255,7 +15246,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/d70040b2-0621-5c1b-aca1-e060877fff43>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Crest" ;
+    skos:prefLabel "microhabitat - crest" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15297,7 +15288,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/d804e15a-d092-509a-b07c-9cd97b7db757>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IN" ;
+    skos:prefLabel "taxon code - IN" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15325,14 +15316,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/d8bb72ce-d609-553c-b696-21c671cc9c3a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "No medium or coarse macropores" ;
+    skos:prefLabel "no medium or coarse macropores" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/d8ee1363-1d0f-5a15-9633-1a4e42151882>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Moderately strong rock (50-100 MPa)" ;
+    skos:prefLabel "moderately strong rock (50-100 MPa)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15396,7 +15387,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/d958b180-ff63-56c5-a39a-4d04bd07207b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Isolated tussock grasses" ;
+    skos:prefLabel "Isolated Tussock Grasses" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15495,7 +15486,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/dad56df8-24b9-5648-9be5-7a49f20394d8>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Iron" ;
+    skos:prefLabel "microhabitat - iron" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15567,14 +15558,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/dbc20b66-84b7-5e72-83e9-9091be8d7de7>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Seen" ;
+    skos:prefLabel "seen" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/dc1bdfa6-5315-5b03-bd00-6b8cd4ebb256>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Unconsolidated material (unidentified)" ;
+    skos:prefLabel "unconsolidated material (unidentified)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15630,14 +15621,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/dce85d57-a8fc-5b5a-ab17-e4f9baf32725>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Herbs/forbs" ;
+    skos:prefLabel "microhabitat - herbs/forbs" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/dcf638f0-1c69-5b90-9457-62c51dda7645>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Sandy (grains prominent)" ;
+    skos:prefLabel "sandy (grains prominent)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15700,7 +15691,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/de3a894e-9dc3-5841-b43a-92cff5e10662>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Open depression (vale)" ;
+    skos:prefLabel "open depression (vale)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15827,7 +15818,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e032a442-4482-5a5a-8bd9-8b71f57db7a5>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Clay Content (vertosols only)" ;
+    skos:prefLabel "clay content (vertosols only)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15883,7 +15874,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e1196d9c-ac2d-5f56-9f1f-432bf3c0b017>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IHY" ;
+    skos:prefLabel "taxon code - IHY" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15897,7 +15888,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e13edfb1-b27f-5f73-ac06-bb40b2520684>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Blow-out" ;
+    skos:prefLabel "blow-out" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15911,7 +15902,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e1747781-ed7d-59da-83f8-08a94c0f5242>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Dependent young (in nest)" ;
+    skos:prefLabel "Dependent young - in nest" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15939,7 +15930,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e1b67442-9751-5e97-99fc-4788eb0f5e82>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IB" ;
+    skos:prefLabel "taxon code - IB" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15968,7 +15959,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e21a15e5-1b30-49f5-a754-77ce14a714ab>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - Inactive" ;
+    skos:prefLabel "observation method tier 3 - inactive" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -15982,14 +15973,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e237bdc2-8d42-52ba-9885-ee9ab013106d>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Resprouting" ;
+    skos:prefLabel "resprouting" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/e23f2383-38f1-5316-9813-40a47b13b356>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Cobble (51-250 mm)" ;
+    skos:prefLabel "cobble (51-250 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16003,7 +15994,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e2609e32-562d-5224-9b02-1ac2b46e7cab>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Walking track (incl animal path)" ;
+    skos:prefLabel "walking track (including animal path)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16024,14 +16015,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e28adc38-5e40-5795-93d1-6582d0013f7e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Sparse grassland" ;
+    skos:prefLabel "Sparse Grassland" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/e293c90b-383d-5c37-a4e2-aa822e970864>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Diffuse (>100mm)" ;
+    skos:prefLabel "diffuse (>100mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16153,7 +16144,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e417f294-9da1-5003-a4ef-f193d12b11bf>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Fixed (smear)" ;
+    skos:prefLabel "fixed - smear" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16216,7 +16207,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e4d4da9d-cfb2-5beb-8941-f34734d80230>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- APA" ;
+    skos:prefLabel "taxon code - APA" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16330,14 +16321,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e6240311-a94d-5e25-832f-b50500c73815>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Saline (visible salt)" ;
+    skos:prefLabel "saline (visible salt)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/e62fba0a-6bf3-5151-bcf7-27ea7c655285>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "camera trap feature- bait station" ;
+    skos:prefLabel "camera trap feature - bait station" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16414,7 +16405,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e71cb4a3-7fe0-5ce5-a9bb-eefc3973ca88>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Leaf litter" ;
+    skos:prefLabel "microhabitat - leaf litter" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16558,7 +16549,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/e9adbb55-dd39-4df1-a0d8-a3d784208ccc>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - Vertebrate derived" ;
+    skos:prefLabel "observation method tier 3 - vertebrate derived" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16571,8 +16562,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/e9e21ffa-d900-5352-9fd4-b9111405ff80>
     a skos:Concept ;
+    dwc:scientificName "Capra hircus" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Goat (Capra hircus)" ;
+    skos:prefLabel "Goat" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16594,7 +16586,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ea48040d-b81b-428a-b620-51bc019171aa>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Significant natural disturbances" ;
+    skos:prefLabel "significant natural disturbances" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16660,7 +16652,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ebc11b32-80e7-5753-8dcd-d364044e900d>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Live shrub" ;
+    skos:prefLabel "microhabitat - live shrub" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16697,7 +16689,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ec3886ce-d13d-5e27-9ffc-b79a30c51277>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "trapping method- Dry" ;
+    skos:prefLabel "trapping method - dry" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16755,35 +16747,35 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ed095396-913b-553b-8a80-648ed586489b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "moisture status- Dry" ;
+    skos:prefLabel "moisture status - dry" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ed3ef29c-00f5-525c-aea5-cc915e752754>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Recently fledged young" ;
+    skos:prefLabel "recently fledged young" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ed4a4d2c-599d-56bc-9f73-9329ab2f967a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Fouled water source" ;
+    skos:prefLabel "fouled water source" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ed5596ea-71d1-5fb3-9b68-1265abc8bcdb>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "500 - 1000" ;
+    skos:prefLabel "aerial experience hours - 500-1000h" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ed672d8c-121b-5d08-97c3-c10f7cc6ba54>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Hortic" ;
+    skos:prefLabel "hortic" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16797,7 +16789,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ed8b2867-5760-4a98-8a06-966a2da7c48f>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - Air" ;
+    skos:prefLabel "observation method tier 3 - air" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16826,28 +16818,28 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/edf6435c-840e-548f-97d8-fa408d1b7e93>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Clear (20-50 mm)" ;
+    skos:prefLabel "clear (20-50 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ee125e07-06f3-583a-9b65-ccb0183a1044>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "State government department" ;
+    skos:prefLabel "State Government Department" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ee1f6672-56cb-5267-ae9a-0ebc88c5a9c1>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "number of traps- 3" ;
+    skos:prefLabel "number of traps - 3" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ee3219ca-ab0e-5ad7-b6f0-7a1348aebba6>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Ferricrete" ;
+    skos:prefLabel "ferricrete" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16855,7 +16847,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "MVS 35" ;
-    skos:prefLabel "Blue grass (Dichanthium) and tall bunch grass (Vitiveria syn: Chrysopogon) tussock grasslands" ;
+    skos:prefLabel "Blue Grass (Dichanthium) and Tall Bunch Grass (Vitiveria syn: Chrysopogon) Tussock Grasslands" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16897,7 +16889,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ee80985f-cf32-5dfe-9ffd-2f9f91db0653>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Lower canopy" ;
+    skos:prefLabel "microhabitat - lower canopy" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16925,7 +16917,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ef30ff33-fb9d-5a27-b79b-42bac25f98aa>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- AU" ;
+    skos:prefLabel "taxon code - AU" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16939,14 +16931,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ef5d653b-7d5a-52b8-9bcf-7adfd6ef77ad>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Clayey sand" ;
+    skos:prefLabel "clayey sand" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/ef6e5a6b-335d-5964-9843-1e77e41e43d2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Largest peds (in the type of soil observation described), parting to" ;
+    skos:prefLabel "largest peds (in the type of soil observation described), parting to" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -16990,7 +16982,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f0236a7c-f31e-5dfb-be89-d22cf1acfba2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Mid canopy" ;
+    skos:prefLabel "microhabitat - mid canopy" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17074,8 +17066,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/f0e22f49-83ff-568e-9522-5f6be4bbe614>
     a skos:Concept ;
+    dwc:scientificName "Equus caballus" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Horse (Equus caballus)" ;
+    skos:prefLabel "Horse" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17097,7 +17090,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f125acdb-8cf9-53f6-b02f-38afd3cb2155>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Highly disturbed" ;
+    skos:prefLabel "highly disturbed" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17118,7 +17111,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f1408c3b-32e3-5b13-951c-ebc9ac5db3bf>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "horizon boundary distinctness- Sharp (<5 mm)" ;
+    skos:prefLabel "horizon boundary distinctness - sharp (<5 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17132,7 +17125,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f18f0758-20d4-516f-a7b5-f01c884520b2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Fine gravelly or small pebbles (2-6 mm)" ;
+    skos:prefLabel "fine gravelly or small pebbles (2-6 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17146,7 +17139,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f1c3145c-ff9d-5303-8281-e2a9866167d7>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Hillslope" ;
+    skos:prefLabel "hillslope" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17189,7 +17182,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "S" ;
-    skos:prefLabel "compass direction - South" ;
+    skos:prefLabel "South" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17203,7 +17196,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f29cfa1b-c126-5fae-a678-29b27bc592d4>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IST" ;
+    skos:prefLabel "taxon code - IST" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17260,14 +17253,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f324bfab-4b6c-5fbb-8ffc-2eec4d18cd6a>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Episodic-Gypsic" ;
+    skos:prefLabel "episodic-gypsic" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/f32a1621-ecc3-5054-b999-e1d3e098d49f>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Off-track (no defined path)" ;
+    skos:prefLabel "off-track (no defined path)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17282,14 +17275,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f361712b-db6f-5804-931b-24c5465ed351>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil drainage- Rapid" ;
+    skos:prefLabel "soil drainage - rapid" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/f369f808-e15c-58de-bf35-d37df047121b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "fauna sign- skeletal remains" ;
+    skos:prefLabel "fauna sign - skeletal remains" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17319,7 +17312,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f38db675-d185-5bc3-ba02-3c30394b38dc>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Bar (stream bar)" ;
+    skos:prefLabel "stream bar" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17347,7 +17340,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f3f28b66-992f-5c88-b39a-d0d009d7895d>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- On" ;
+    skos:prefLabel "microhabitat - on" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17361,7 +17354,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f41958cf-21dc-5222-b01d-fb9d94743cfc>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Partially degenerated (estimate 1-2 weeks)" ;
+    skos:prefLabel "partially degenerated (estimate 1-2 weeks)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17383,7 +17376,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "SE" ;
-    skos:prefLabel "compass direction - South East" ;
+    skos:prefLabel "South East" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17580,28 +17573,28 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f65af1f2-c659-5022-a0f0-b2703d66e737>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "soil horizon- O" ;
+    skos:prefLabel "soil horizon - O" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/f66a2d61-5903-5c73-8e42-d9ba20bc43eb>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Mid-slope" ;
+    skos:prefLabel "mid-slope" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/f67fb429-d7ea-5958-b779-3c626e3f401e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Medium (2-6 mm)" ;
+    skos:prefLabel "medium (2-6 mm)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/f685706d-3fd1-5946-afa5-1a06e41eab43>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "No effective disturbance; natural" ;
+    skos:prefLabel "no effective disturbance; natural" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17664,14 +17657,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f73cee78-1dd5-5335-a1de-a77183b40144>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Soil pit" ;
+    skos:prefLabel "soil pit" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/f75264c6-1e37-50e8-98d3-238025b5c3b5>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Ferruginous (iron)" ;
+    skos:prefLabel "ferruginous (iron)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17713,7 +17706,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f7d133e9-6b5d-5789-97cb-219b46049005>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Pool" ;
+    skos:prefLabel "microhabitat - pool" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17777,7 +17770,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f8547a88-3e49-4db9-8e53-9dbb2fb3b69e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "observation method tier 3 - Recent" ;
+    skos:prefLabel "observation method tier 3 - recent" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17826,7 +17819,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f959562e-27fc-5d55-9b5d-74c233eb2345>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Building" ;
+    skos:prefLabel "microhabitat - building" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17840,28 +17833,28 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/f98958fa-027d-5001-ab36-82bf2168c88c>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Fishes" ;
+    skos:prefLabel "fishes" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/f99876ce-4384-5d25-85c9-ef212ebdbcf5>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Very rocky (20-50% bedrock exposed)" ;
+    skos:prefLabel "very rocky (20-50% bedrock exposed)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/f99a1f6f-d1ef-496b-a557-483fe3a45da2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Killing bottle" ;
+    skos:prefLabel "killing bottle" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/f9b949a6-5631-5e84-b348-904ab331dea2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Very gently inclined (1-3%)" ;
+    skos:prefLabel "very gently inclined (1-3%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17890,7 +17883,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/fa02b0ea-bc65-55c8-a87e-518505ed35ac>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- IOR" ;
+    skos:prefLabel "taxon code - IOR" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17932,7 +17925,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/faa117f1-0649-55e3-9226-5ea93af17b3e>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "microhabitat- Farmland" ;
+    skos:prefLabel "microhabitat - Farmland" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17967,7 +17960,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/fb1b5882-1e51-503f-874d-b1309df36508>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "scratchings (arboreal)" ;
+    skos:prefLabel "scratchings - arboreal" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -17995,14 +17988,14 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/fc14047c-999b-571d-98db-92776e5ef759>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Swamp hummock" ;
+    skos:prefLabel "swamp hummock" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/def/nrm/fc4a9c65-ded5-5974-a7e2-0e7b3ede2fb2>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Gently inclined (3-10%)" ;
+    skos:prefLabel "gently inclined (3-10%)" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -18086,7 +18079,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/fe471531-c329-5d14-94e8-32cea05e0313>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "Propylene glycol" ;
+    skos:prefLabel "propylene glycol" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -18195,7 +18188,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/ffca025d-ccca-5070-82ec-597d318b99ae>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:prefLabel "taxon code- APD" ;
+    skos:prefLabel "taxon code - APD" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
@@ -18208,8 +18201,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/def/nrm/ffdac5da-c5a1-54e9-8e71-71c0503f4491>
     a skos:Concept ;
+    dwc:scientificName "Canis lupus" ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:altLabel "Canis lupus" ;
     skos:prefLabel "wolf" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .

--- a/vocab_files/categorical_collections/luts/condition-vertebrate-pest-types.ttl
+++ b/vocab_files/categorical_collections/luts/condition-vertebrate-pest-types.ttl
@@ -10,7 +10,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:CategoricalConceptMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/condition-vertebrate-pest-types.ttl"^^xsd:anyURI ;
     urnp:categoricalCollection <https://linked.data.gov.au/def/nrm/579449ad-4cea-4272-afa3-67f207941fb1> ;
-    urnp:categoricalConcept <https://linked.data.gov.au/def/nrm/57629205-2427-5988-9920-9605574847a2> ;
+    urnp:categoricalConcept <https://linked.data.gov.au/def/nrm/9a292b27-007c-5e1a-a7e2-d8536ea56c2b> ;
     urnp:conceptDefinition "The type of pest animal present in the system." ;
     urnp:conceptSource "https://core.vocabs.paratoo.tern.org.au/api/lut-condition-vertebrate-pest-types"^^xsd:anyURI ;
 .
@@ -28,7 +28,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:CategoricalConceptMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/condition-vertebrate-pest-types.ttl"^^xsd:anyURI ;
     urnp:categoricalCollection <https://linked.data.gov.au/def/nrm/579449ad-4cea-4272-afa3-67f207941fb1> ;
-    urnp:categoricalConcept <https://linked.data.gov.au/def/nrm/801ee910-8d5c-5829-b20c-08ab22b35b9e> ;
+    urnp:categoricalConcept <https://linked.data.gov.au/def/nrm/05ffeed3-fd7b-5ec8-864f-6a6632502373> ;
     urnp:conceptDefinition "The type of pest animal present in the system." ;
     urnp:conceptSource "https://core.vocabs.paratoo.tern.org.au/api/lut-condition-vertebrate-pest-types"^^xsd:anyURI ;
 .
@@ -37,7 +37,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:CategoricalConceptMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/condition-vertebrate-pest-types.ttl"^^xsd:anyURI ;
     urnp:categoricalCollection <https://linked.data.gov.au/def/nrm/579449ad-4cea-4272-afa3-67f207941fb1> ;
-    urnp:categoricalConcept <https://linked.data.gov.au/def/nrm/aed51aa9-e2f0-571d-b3aa-bebf932fe94f> ;
+    urnp:categoricalConcept <https://linked.data.gov.au/def/nrm/f0e22f49-83ff-568e-9522-5f6be4bbe614> ;
     urnp:conceptDefinition "The type of pest animal present in a system." ;
     urnp:conceptSource "https://core.vocabs.paratoo.tern.org.au/api/lut-condition-vertebrate-pest-types"^^xsd:anyURI ;
 .
@@ -46,7 +46,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:CategoricalConceptMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/condition-vertebrate-pest-types.ttl"^^xsd:anyURI ;
     urnp:categoricalCollection <https://linked.data.gov.au/def/nrm/579449ad-4cea-4272-afa3-67f207941fb1> ;
-    urnp:categoricalConcept <https://linked.data.gov.au/def/nrm/0ae90953-9c95-54d7-985c-036c6134502a> ;
+    urnp:categoricalConcept <https://linked.data.gov.au/def/nrm/58993c3a-9237-5112-aec9-0e6bf776b242> ;
     urnp:conceptDefinition "The type of pest animal present in the system." ;
     urnp:conceptSource "https://core.vocabs.paratoo.tern.org.au/api/lut-condition-vertebrate-pest-types"^^xsd:anyURI ;
 .
@@ -84,13 +84,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     dcterms:source "https://core.vocabs.paratoo.tern.org.au/api/lut-condition-vertebrate-pest-types"^^xsd:anyURI ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:member
-        <https://linked.data.gov.au/def/nrm/0ae90953-9c95-54d7-985c-036c6134502a> ,
+        <https://linked.data.gov.au/def/nrm/05ffeed3-fd7b-5ec8-864f-6a6632502373> ,
         <https://linked.data.gov.au/def/nrm/19f2da82-66a4-5b46-96b1-4dc2e2b0c9e1> ,
         <https://linked.data.gov.au/def/nrm/1cedcaf0-6a43-5f69-8426-983a0354670c> ,
-        <https://linked.data.gov.au/def/nrm/57629205-2427-5988-9920-9605574847a2> ,
-        <https://linked.data.gov.au/def/nrm/801ee910-8d5c-5829-b20c-08ab22b35b9e> ,
+        <https://linked.data.gov.au/def/nrm/58993c3a-9237-5112-aec9-0e6bf776b242> ,
         <https://linked.data.gov.au/def/nrm/83aff15f-417f-5026-a0a0-b37f3fc9cdeb> ,
-        <https://linked.data.gov.au/def/nrm/aed51aa9-e2f0-571d-b3aa-bebf932fe94f> ,
+        <https://linked.data.gov.au/def/nrm/9a292b27-007c-5e1a-a7e2-d8536ea56c2b> ,
+        <https://linked.data.gov.au/def/nrm/f0e22f49-83ff-568e-9522-5f6be4bbe614> ,
         <https://linked.data.gov.au/def/nrm/ffdac5da-c5a1-54e9-8e71-71c0503f4491> ;
     skos:prefLabel "Condition vertebrate pest types" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/condition-vertebrate-pest-types.ttl"^^xsd:anyURI ;


### PR DESCRIPTION
This is a massive clean-up of names for LUTs identified with naming discrepancies (includes, uppercase/lowercase fixes, duplicate concepts, and use of prefixes and brackets).