### PR TITLE
Updated the value type if trees count OPs in basal wedge protocol to Integer

### DIFF
--- a/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/borderline-trees-count.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/borderline-trees-count.ttl
@@ -11,6 +11,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/84b0a152-e6f6-4ea2-b973-04238034bb52> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/36580cad-0509-4642-a450-47f3433ad244> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/a7d605e0-7d90-473e-aac0-21cdf380576f> ;
-    urnp:valueType tern:Float ;
+    urnp:valueType tern:Integer ;
 .
 

--- a/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/in-trees-count.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/in-trees-count.ttl
@@ -11,6 +11,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/84b0a152-e6f6-4ea2-b973-04238034bb52> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/8fea241f-8e98-4814-b9b9-db1bd5446910> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/a7d605e0-7d90-473e-aac0-21cdf380576f> ;
-    urnp:valueType tern:Float ;
+    urnp:valueType tern:Integer ;
 .
 


### PR DESCRIPTION
This PR updated the value type of 2 trees count relevant OPs to `tern:Integer`.