### PR TITLE
Linked attributes to OPs for partial modules

### DIFF
--- a/vocab_files/attributes_by_module/cover-attributes/enhanced-protocol/collection.ttl
+++ b/vocab_files/attributes_by_module/cover-attributes/enhanced-protocol/collection.ttl
@@ -8,9 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Collection ;
     dcterms:description "The attributes of the Cover - Enhanced protocol." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:member
-        <https://linked.data.gov.au/def/nrm/1080a165-ebfe-42d0-bae5-2acf90d59eb3> ,
-        <https://linked.data.gov.au/def/nrm/c6317606-d5a1-44f4-a5c0-d582264b84fb> ;
+    skos:member <https://linked.data.gov.au/def/nrm/1080a165-ebfe-42d0-bae5-2acf90d59eb3> ;
     skos:prefLabel "Cover - Enhanced protocol Attributes" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attributes_by_module/cover-attributes/enhanced-protocol/collection.ttl"^^xsd:anyURI ;
 .

--- a/vocab_files/attributes_by_module/cover-attributes/standard-protocol/collection.ttl
+++ b/vocab_files/attributes_by_module/cover-attributes/standard-protocol/collection.ttl
@@ -8,9 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Collection ;
     dcterms:description "The attributes of the Cover - Standard protocol." ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
-    skos:member
-        <https://linked.data.gov.au/def/nrm/1080a165-ebfe-42d0-bae5-2acf90d59eb3> ,
-        <https://linked.data.gov.au/def/nrm/c6317606-d5a1-44f4-a5c0-d582264b84fb> ;
+    skos:member <https://linked.data.gov.au/def/nrm/1080a165-ebfe-42d0-bae5-2acf90d59eb3> ;
     skos:prefLabel "Cover - Standard protocol Attributes" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attributes_by_module/cover-attributes/standard-protocol/collection.ttl"^^xsd:anyURI ;
 .

--- a/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/borderline-trees-count.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/borderline-trees-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/borderline-trees-count.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ;
+    urnp:hasAttribute <https://linked.data.gov.au/def/nrm/d06bf3e4-f59d-47fb-b780-bb089b298d83> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/84b0a152-e6f6-4ea2-b973-04238034bb52> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/36580cad-0509-4642-a450-47f3433ad244> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/a7d605e0-7d90-473e-aac0-21cdf380576f> ;

--- a/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/in-trees-count.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/in-trees-count.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/basal-wedge-protocol/basal-area.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/ae71c3f6-d430-400f-a1d4-97a333b4ee02> ;
+    urnp:hasAttribute <https://linked.data.gov.au/def/nrm/d06bf3e4-f59d-47fb-b780-bb089b298d83> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/84b0a152-e6f6-4ea2-b973-04238034bb52> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/8fea241f-8e98-4814-b9b9-db1bd5446910> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/a7d605e0-7d90-473e-aac0-21cdf380576f> ;

--- a/vocab_files/observable_properties_by_module/fire/field-species-name.ttl
+++ b/vocab_files/observable_properties_by_module/fire/field-species-name.ttl
@@ -10,6 +10,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     urnp:featureType
         <http://linked.data.gov.au/def/tern-cv/b293a07e-a1ff-4a4e-9af9-922057d5d742> ,
         <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:hasAttribute <https://linked.data.gov.au/def/nrm/6b7de8cd-6b9c-4ee7-a088-b0dd6570d450> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/75002e1e-7866-4264-9e20-8569743ea4f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/26f843a5-e1ed-46da-b22b-053e567e3227> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/91a54c7c-48ff-402d-a761-ed4fd4ad4a4b> ;

--- a/vocab_files/observable_properties_by_module/sign-based-fauna-survey/plot-sign-search-protocol/attributable-fauna-species.ttl
+++ b/vocab_files/observable_properties_by_module/sign-based-fauna-survey/plot-sign-search-protocol/attributable-fauna-species.ttl
@@ -8,6 +8,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/sign-based-fauna-survey/plot-sign-search-protocol/attributable-fauna-species.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/4507e510-bf25-467b-a97e-abd56776507a> ;
+    urnp:hasAttribute
+        <https://linked.data.gov.au/def/nrm/e14e183e-baa8-4989-8d5d-ffb255ee4374> ,
+        <https://linked.data.gov.au/def/nrm/e235852a-dccf-49fc-9b36-3b0c455af876> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/831f9c5e-f56a-4837-b484-0065debb8403> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/22fae1ac-9d23-5b11-9fc7-f4f29f900bdf> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/7347c555-311b-49ed-8928-ab57880a6916> ;

--- a/vocab_files/observable_properties_by_module/sign-based-fauna-survey/track-stations-protocol/attributable-fauna-species.ttl
+++ b/vocab_files/observable_properties_by_module/sign-based-fauna-survey/track-stations-protocol/attributable-fauna-species.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/sign-based-fauna-survey/track-stations-protocol/attributable-fauna-species.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/4507e510-bf25-467b-a97e-abd56776507a> ;
+    urnp:hasAttribute <https://linked.data.gov.au/def/nrm/6f6a3655-4347-4219-bfe1-9e4023d3a80f> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/000b05f2-f8ae-4ca1-b8da-ee7d95da97f5> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/22fae1ac-9d23-5b11-9fc7-f4f29f900bdf> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/fff59959-79b9-44f5-916d-16733f58cec5> ;

--- a/vocab_files/observable_properties_by_module/sign-based-fauna-survey/vehicle-track-protocol/attributable-fauna-species.ttl
+++ b/vocab_files/observable_properties_by_module/sign-based-fauna-survey/vehicle-track-protocol/attributable-fauna-species.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/sign-based-fauna-survey/vehicle-track-protocol/attributable-fauna-species.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/4507e510-bf25-467b-a97e-abd56776507a> ;
+    urnp:hasAttribute <https://linked.data.gov.au/def/nrm/6f6a3655-4347-4219-bfe1-9e4023d3a80f> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/be7baddd-63a4-4b50-9b1b-06ebebb2f834> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/22fae1ac-9d23-5b11-9fc7-f4f29f900bdf> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/d885edf1-fbdb-47f2-9ddf-098e98fb82fe> ;


### PR DESCRIPTION
This PR linked attributes to OPs for partial modules, whose data models are reviewed internally, in version 2.