### PR TITLE
Added attribute POM to OP DBH in Basal area

### DIFF
--- a/vocab_files/observable_properties_by_module/basal-area/dbh-protocol/diameter-at-breast-height.ttl
+++ b/vocab_files/observable_properties_by_module/basal-area/dbh-protocol/diameter-at-breast-height.ttl
@@ -8,6 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/basal-area/dbh-protocol/diameter-at-breast-height.ttl"^^xsd:anyURI ;
     urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
+    urnp:hasAttribute <https://linked.data.gov.au/def/nrm/9faeafe6-0d01-41aa-b38b-a6b56eda0dda> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/37d541e6-756f-4248-88cd-ade4775e3b7b> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/6e1c8b97-3655-4a22-9647-02f2c756e789> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/5a00862b-a885-472e-8bee-561ec502653f> ;


### PR DESCRIPTION
This PR added attribute `point of measurement` to OP `diameter at breast height` in Basal area - DBH protocol.