### PR TITLE
Updated LUT label 'East'

### DIFF
--- a/vocab_files/categorical_collections/luts/categorical_concepts.ttl
+++ b/vocab_files/categorical_collections/luts/categorical_concepts.ttl
@@ -941,7 +941,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:notation "E" ;
-    skos:prefLabel "East" ;
+    skos:prefLabel "compass direction - East" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 


### PR DESCRIPTION
Added 'compass direction' as a prefix for East, based on the usecase and prescribed by Guru.