### PR TITLE
Added new LUT `fire ignition date accuracies` & Updated some feature types

### DIFF
--- a/vocab_files/attribute_concepts/fire-ignition-date-accuracy.ttl
+++ b/vocab_files/attribute_concepts/fire-ignition-date-accuracy.ttl
@@ -12,7 +12,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:definition "An estimate of the date accuray level (month or year) since the last fire event." ;
     skos:prefLabel "fire ignition date accuracy" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/attribute_concepts/fire-ignition-date-accuracy.ttl"^^xsd:anyURI ;
-    tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/need-endpoint> ;
+    tern:hasCategoricalCollection <https://linked.data.gov.au/def/nrm/8efd625e-23dc-4ac5-8ed7-b9673902866b> ;
     tern:isAttributeOf tern:Attribute ;
     tern:valueType tern:IRI ;
 .

--- a/vocab_files/categorical_collections/luts/categorical_concepts.ttl
+++ b/vocab_files/categorical_collections/luts/categorical_concepts.ttl
@@ -5839,6 +5839,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 
+<https://linked.data.gov.au/def/nrm/484fd7b7-0172-4b60-a8a3-e473e35ab30c>
+    a skos:Concept ;
+    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
+    skos:prefLabel "month" ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
+.
+
 <https://linked.data.gov.au/def/nrm/4876eae6-5d6f-5912-b2ea-3b107d7eff9b>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
@@ -11882,6 +11889,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
     skos:prefLabel "rill water erosion- Minor" ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
+.
+
+<https://linked.data.gov.au/def/nrm/95a238b7-f66c-4e36-9620-7b9e894c973f>
+    a skos:Concept ;
+    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
+    skos:prefLabel "year" ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/categorical_concepts.ttl"^^xsd:anyURI ;
 .
 

--- a/vocab_files/categorical_collections/luts/collection-members.ttl
+++ b/vocab_files/categorical_collections/luts/collection-members.ttl
@@ -194,6 +194,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         <https://linked.data.gov.au/def/nrm/889a0ec6-fecc-55cc-a33c-492aecba4d4f> ,
         <https://linked.data.gov.au/def/nrm/8d7c2dec-d8ba-5369-9b3b-be3ce76fec88> ,
         <https://linked.data.gov.au/def/nrm/8d89b68a-22a5-48f9-af90-a8837dd21fb0> ,
+        <https://linked.data.gov.au/def/nrm/8efd625e-23dc-4ac5-8ed7-b9673902866b> ,
         <https://linked.data.gov.au/def/nrm/90a0f5d0-0ac9-5723-acc5-f1c3ce8cd57e> ,
         <https://linked.data.gov.au/def/nrm/9131e67d-f1ae-4dbc-8658-90810a445eb2> ,
         <https://linked.data.gov.au/def/nrm/91a39bbd-6e26-55f1-a36a-8a4b36d62228> ,

--- a/vocab_files/categorical_collections/luts/fire-ignition-date-accuracies.ttl
+++ b/vocab_files/categorical_collections/luts/fire-ignition-date-accuracies.ttl
@@ -1,0 +1,38 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX urnc: <urn:class:>
+PREFIX urnp: <urn:property:>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<https://linked.data.gov.au/def/nrm/559bbc48-022f-4974-888c-8563598be638>
+    a urnc:CategoricalConceptMeta ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/fire-ignition-date-accuracies.ttl"^^xsd:anyURI ;
+    urnp:categoricalCollection <https://linked.data.gov.au/def/nrm/8efd625e-23dc-4ac5-8ed7-b9673902866b> ;
+    urnp:categoricalConcept <https://linked.data.gov.au/def/nrm/95a238b7-f66c-4e36-9620-7b9e894c973f> ;
+    urnp:conceptDefinition "Refers to the 'year' accuracy of the fire ignition date." ;
+    urnp:conceptSource "Laws M, Morgan R, McCallum K, Bignall J, Cox B, O'Neill S, Sparrow B. (2023) Fire Severity Module. In ‘Ecological Field Monitoring Protocols Manual using the Ecological Monitoring System Australia’. (Eds S O’Neill, K Irvine, A Tokmakoff, B Sparrow). TERN, Adelaide."^^xsd:string ;
+.
+
+<https://linked.data.gov.au/def/nrm/f6c4ed3a-fd42-4c23-bb8e-01aa564477cb>
+    a urnc:CategoricalConceptMeta ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/fire-ignition-date-accuracies.ttl"^^xsd:anyURI ;
+    urnp:categoricalCollection <https://linked.data.gov.au/def/nrm/8efd625e-23dc-4ac5-8ed7-b9673902866b> ;
+    urnp:categoricalConcept <https://linked.data.gov.au/def/nrm/484fd7b7-0172-4b60-a8a3-e473e35ab30c> ;
+    urnp:conceptDefinition "Refers to the 'month' accuracy of the fire ignition date." ;
+    urnp:conceptSource "Laws M, Morgan R, McCallum K, Bignall J, Cox B, O'Neill S, Sparrow B. (2023) Fire Severity Module. In ‘Ecological Field Monitoring Protocols Manual using the Ecological Monitoring System Australia’. (Eds S O’Neill, K Irvine, A Tokmakoff, B Sparrow). TERN, Adelaide."^^xsd:string ;
+.
+
+<https://linked.data.gov.au/def/nrm/8efd625e-23dc-4ac5-8ed7-b9673902866b>
+    a skos:Collection ;
+    dcterms:description "Refers to the fire ignition date accuracies." ;
+    dcterms:source "Laws M, Morgan R, McCallum K, Bignall J, Cox B, O'Neill S, Sparrow B. (2023) Fire Severity Module. In ‘Ecological Field Monitoring Protocols Manual using the Ecological Monitoring System Australia’. (Eds S O’Neill, K Irvine, A Tokmakoff, B Sparrow). TERN, Adelaide."^^xsd:string ;
+    rdfs:isDefinedBy <https://linked.data.gov.au/def/nrm> ;
+    skos:member
+        <https://linked.data.gov.au/def/nrm/484fd7b7-0172-4b60-a8a3-e473e35ab30c> ,
+        <https://linked.data.gov.au/def/nrm/95a238b7-f66c-4e36-9620-7b9e894c973f> ;
+    skos:prefLabel "Fire ignition date accuracies" ;
+    schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/categorical_collections/luts/fire-ignition-date-accuracies.ttl"^^xsd:anyURI ;
+.
+

--- a/vocab_files/observable_properties_by_module/cover/standard-protocol/dead-branch.ttl
+++ b/vocab_files/observable_properties_by_module/cover/standard-protocol/dead-branch.ttl
@@ -7,7 +7,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/57b670ba-bffc-44af-87bc-7da1d9169d7f>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/standard-protocol/dead-branch.ttl"^^xsd:anyURI ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/8282fb22-4135-415c-8ca2-317860d102fb> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc9aa42b-f908-4c73-adb2-d1847eee4ea3> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/dd25002d-6fd8-4c1f-a1df-c556d43daea8> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/aa1525f9-c3f2-4f7d-98cc-6a7d3aec9d8a> ;

--- a/vocab_files/observable_properties_by_module/cover/standard-protocol/in-canopy-sky.ttl
+++ b/vocab_files/observable_properties_by_module/cover/standard-protocol/in-canopy-sky.ttl
@@ -7,7 +7,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/c8f9f7b6-0832-4779-bfc5-8c4181583fbd>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/standard-protocol/in-canopy-sky.ttl"^^xsd:anyURI ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/8282fb22-4135-415c-8ca2-317860d102fb> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc9aa42b-f908-4c73-adb2-d1847eee4ea3> ;
     urnp:observableProperty <https://linked.data.gov.au/def/nrm/85bdd25a-fa08-49de-9f0b-98895cb79aa6> ;
     urnp:protocolModule <https://linked.data.gov.au/def/nrm/aa1525f9-c3f2-4f7d-98cc-6a7d3aec9d8a> ;

--- a/vocab_files/observable_properties_by_module/cover/standard-protocol/plant-height.ttl
+++ b/vocab_files/observable_properties_by_module/cover/standard-protocol/plant-height.ttl
@@ -8,7 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/def/nrm/fd759504-ba9e-4b00-bb8f-b10494e96d3c>
     a urnc:ObservablePropertyMeta ;
     schema:url "https://github.com/ternaustralia/dawe-rlp-vocabs/tree/main/vocab_files/observable_properties_by_module/cover/standard-protocol/plant-height.ttl"^^xsd:anyURI ;
-    urnp:featureType <http://linked.data.gov.au/def/tern-cv/8282fb22-4135-415c-8ca2-317860d102fb> ;
+    urnp:featureType <http://linked.data.gov.au/def/tern-cv/b311c0d3-4a1a-4932-a39c-f5cdc1afa611> ;
     urnp:maxExclusive 100 ;
     urnp:minExclusive 0 ;
     urnp:observablePropertiesCollection <https://linked.data.gov.au/def/nrm/bc9aa42b-f908-4c73-adb2-d1847eee4ea3> ;


### PR DESCRIPTION
This PR added a new LUT `fire ignition date accuracies` to be used by attribute `fire ignition date accuracy`.
Also updated the feature type of OPs `dead branch`, `plant height`, `in-canopy sky` in Cover-Standard, from `land surface` to `plant occurrence`.